### PR TITLE
Reorder API list in Messaging API file

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -17,6 +17,161 @@ tags:
   - name: messaging-api-blob
 
 paths:
+  # Webhook
+  "/v2/bot/channel/webhook/endpoint":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
+      tags:
+        - messaging-api
+      operationId: getWebhookEndpoint
+      description: "Get webhook endpoint information"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/GetWebhookEndpointResponse"
+              examples:
+                ACTIVE:
+                  summary: "If the webhook URL was set and the webhook usage is enabled"
+                  value:
+                    endpoint: https://example.com/test
+                    active: true
+                INACTIVE:
+                  summary: "If the webhook URL was set and the webhook usage is disabled"
+                  value:
+                    endpoint: https://example.com/test
+                    active: false
+
+    put:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
+      tags:
+        - messaging-api
+      operationId: setWebhookEndpoint
+      description: "Set webhook endpoint URL"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SetWebhookEndpointRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/channel/webhook/test":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
+      tags:
+        - messaging-api
+      operationId: testWebhookEndpoint
+      description: "Test webhook endpoint"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/TestWebhookEndpointRequest"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/TestWebhookEndpointResponse"
+              example:
+                success: true
+                timestamp: "2020-09-30T05:38:20.031Z"
+                statusCode: 200
+                reason: OK
+                detail: "200"
+
+  # Webhook content
+  "/v2/bot/message/{messageId}/content":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-content
+      servers:
+        - url: "https://api-data.line.me"
+      tags:
+        - messaging-api-blob
+      operationId: getMessageContent
+      description: "Download image, video, and audio data sent from users."
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          description: "Message ID of video or audio"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "*/*":
+              schema:
+                description: "blob response"
+                type: string
+                format: binary
+
+  "/v2/bot/message/{messageId}/content/preview":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-image-or-video-preview
+      servers:
+        - url: "https://api-data.line.me"
+      tags:
+        - messaging-api-blob
+      operationId: getMessageContentPreview
+      description: "Get a preview image of the image or video"
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          description: "Message ID of image or video"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+                description: "blob response"
+
+  "/v2/bot/message/{messageId}/content/transcoding":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#verify-video-or-audio-preparation-status
+      servers:
+        - url: "https://api-data.line.me"
+      tags:
+        - messaging-api-blob
+      operationId: getMessageContentTranscodingByMessageId
+      description: "Verify the preparation status of a video or audio for getting"
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          description: "Message ID of video or audio"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/GetMessageContentTranscodingResponse"
+              example:
+                status: processing
+
+  # Messaging
   "/v2/bot/message/reply":
     post:
       externalDocs:
@@ -153,59 +308,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
 
-  "/v2/bot/message/broadcast":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
-      tags:
-        - messaging-api
-      operationId: broadcast
-      description: "Sends a message to multiple users at any time."
-      parameters:
-        - name: X-Line-Retry-Key
-          in: header
-          required: false
-          schema:
-            type: string
-            format: uuid
-          description: |+
-            Retry key.
-            Specifies the UUID in hexadecimal format (e.g., `123e4567-e89b-12d3-a456-426614174000`) generated by any method.
-            The retry key isn't generated by LINE. Each developer must generate their own retry key.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/BroadcastRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-        "400":
-          description: "Bad Request"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        "403":
-          description: "Forbidden"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        "409":
-          description: "Conflict"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        "429":
-          description: "Too Many Requests"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-
   "/v2/bot/message/narrowcast":
     post:
       externalDocs:
@@ -285,6 +387,60 @@ paths:
                 phase: waiting
                 acceptedTime: 2020-12-03T10:15:30.121Z
 
+  "/v2/bot/message/broadcast":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
+      tags:
+        - messaging-api
+      operationId: broadcast
+      description: "Sends a message to multiple users at any time."
+      parameters:
+        - name: X-Line-Retry-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: |+
+            Retry key.
+            Specifies the UUID in hexadecimal format (e.g., `123e4567-e89b-12d3-a456-426614174000`) generated by any method.
+            The retry key isn't generated by LINE. Each developer must generate their own retry key.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BroadcastRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+        "400":
+          description: "Bad Request"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Forbidden"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        "429":
+          description: "Too Many Requests"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+
+  # Quota
   "/v2/bot/message/quota":
     get:
       externalDocs:
@@ -322,6 +478,7 @@ paths:
               example:
                 "totalUsage": 500
 
+  # Delivery
   "/v2/bot/message/delivery/reply":
     get:
       externalDocs:
@@ -443,6 +600,154 @@ paths:
                 status: ready
                 success: 10000
 
+  # Message validation
+  "/v2/bot/message/validate/reply":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-reply-message
+      tags:
+        - messaging-api
+      operationId: validateReply
+      description: "Validate message objects of a reply message"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ValidateMessageRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/message/validate/push":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-push-message
+      tags:
+        - messaging-api
+      operationId: validatePush
+      description: "Validate message objects of a push message"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ValidateMessageRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/message/validate/multicast":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-multicast-message
+      tags:
+        - messaging-api
+      operationId: validateMulticast
+      description: "Validate message objects of a multicast message"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ValidateMessageRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/message/validate/narrowcast":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-narrowcast-message
+      tags:
+        - messaging-api
+      operationId: validateNarrowcast
+      description: "Validate message objects of a narrowcast message"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ValidateMessageRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/message/validate/broadcast":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-broadcast-message
+      tags:
+        - messaging-api
+      operationId: validateBroadcast
+      description: "Validate message objects of a broadcast message"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ValidateMessageRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  # Aggregation Unit
+  "/v2/bot/message/aggregation/info":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-number-of-units-used-this-month
+      tags:
+        - messaging-api
+      operationId: getAggregationUnitUsage
+      description: "Get number of units used this month"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/GetAggregationUnitUsageResponse"
+              example:
+                numOfCustomAggregationUnits: 22
+
+  "/v2/bot/message/aggregation/list":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-name-list-of-units-used-this-month
+      tags:
+        - messaging-api
+      operationId: getAggregationUnitNameList
+      description: "Get name list of units used this month"
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |+
+            The maximum number of aggregation units you can get per request.
+        - name: start
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |+
+            Value of the continuation token found in the next property of the JSON object returned in the response.
+            If you can't get all the aggregation units in one request, include this parameter to get the remaining array.
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/GetAggregationUnitNameListResponse"
+              example:
+                customAggregationUnits:
+                  - promotion_a
+                  - promotion_b
+                next: jxEWCEEP...
+
+  # Users
   "/v2/bot/profile/{userId}":
     get:
       externalDocs:
@@ -472,6 +777,71 @@ paths:
                 pictureUrl: https://obs.line-apps.com/...
                 statusMessage: Hello, LINE!
 
+  "/v2/bot/followers/ids":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
+      tags:
+        - messaging-api
+      operationId: getFollowers
+      description: "Get a list of users who added your LINE Official Account as a friend"
+      parameters:
+        - name: start
+          in: query
+          required: false
+          description: |+
+            Value of the continuation token found in the next property of the JSON object returned in the response.
+            Include this parameter to get the next array of user IDs.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: "The maximum number of user IDs to retrieve in a single request."
+          schema:
+            type: integer
+            format: int32
+            default: 300
+            maximum: 1000
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/GetFollowersResponse"
+              example:
+                userIds:
+                  - U4af4980629...
+                  - U0c229f96c4...
+                  - U95afb1d4df...
+                next: yANU9IA...
+
+  # Bot
+  "/v2/bot/info":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-bot-info
+      tags:
+        - messaging-api
+      operationId: getBotInfo
+      description: "Get bot info"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/BotInfoResponse"
+              example:
+                userId: Ub9952f8...
+                basicId: "@216ru..."
+                displayName: Example name
+                pictureUrl: https://obs.line-apps.com/...
+                chatMode: chat
+                markAsReadMode: manual
+
+  # Group
   "/v2/bot/group/{groupId}/member/{userId}":
     get:
       externalDocs:
@@ -739,6 +1109,104 @@ paths:
               example:
                 count: 3
 
+  # RichMenu
+  "/v2/bot/richmenu":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#create-rich-menu
+      tags:
+        - messaging-api
+      operationId: createRichMenu
+      description: "Create rich menu"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RichMenuRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/RichMenuIdResponse"
+              example:
+                "richMenuId": "{richMenuId}"
+
+  "/v2/bot/richmenu/validate":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#validate-rich-menu-object
+      tags:
+        - messaging-api
+      operationId: validateRichMenuObject
+      description: "Validate rich menu object"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RichMenuRequest"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/richmenu/{richMenuId}/content":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#download-rich-menu-image
+      servers:
+        - url: "https://api-data.line.me"
+      tags:
+        - messaging-api-blob
+      operationId: getRichMenuImage
+      description: "Download rich menu image."
+      parameters:
+        - name: richMenuId
+          in: path
+          required: true
+          description: "ID of the rich menu with the image to be downloaded"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "OK"
+          content:
+            # TODO check the content-type of the actual implementation and replace here.
+            "*/*":
+              schema:
+                type: string
+                format: binary
+                description: "blob response"
+
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#upload-rich-menu-image
+      servers:
+        - url: "https://api-data.line.me"
+      tags:
+        - messaging-api-blob
+      operationId: setRichMenuImage
+      description: "Upload rich menu image"
+      parameters:
+        - name: richMenuId
+          in: path
+          required: true
+          description: "The ID of the rich menu to attach the image to"
+          schema:
+            type: string
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              description: "blob request"
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: "OK"
+
   "/v2/bot/richmenu/{richMenuId}":
     parameters:
       - name: richMenuId
@@ -789,144 +1257,6 @@ paths:
         "200":
           description: "OK"
 
-  "/v2/bot/richmenu/validate":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-rich-menu-object
-      tags:
-        - messaging-api
-      operationId: validateRichMenuObject
-      description: "Validate rich menu object"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RichMenuRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/richmenu":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#create-rich-menu
-      tags:
-        - messaging-api
-      operationId: createRichMenu
-      description: "Create rich menu"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RichMenuRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/RichMenuIdResponse"
-              example:
-                "richMenuId": "{richMenuId}"
-
-  "/v2/bot/user/{userId}/richmenu":
-    parameters:
-      - name: userId
-        in: path
-        required: true
-        schema:
-          type: string
-        description: "User ID. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-id-of-user
-      tags:
-        - messaging-api
-      operationId: getRichMenuIdOfUser
-      description: "Get rich menu ID of user"
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/RichMenuIdResponse"
-              example:
-                "richMenuId": "{richMenuId}"
-    delete:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-user
-      tags:
-        - messaging-api
-      operationId: unlinkRichMenuIdFromUser
-      description: "Unlink rich menu from user"
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/user/{userId}/richmenu/{richMenuId}":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-user
-      tags:
-        - messaging-api
-      operationId: linkRichMenuIdToUser
-      description: "Link rich menu to user."
-      parameters:
-        - name: userId
-          in: path
-          required: true
-          schema:
-            type: string
-          description: "User ID. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
-        - name: richMenuId
-          in: path
-          required: true
-          schema:
-            type: string
-          description: "ID of a rich menu"
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/richmenu/bulk/link":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-users
-      tags:
-        - messaging-api
-      operationId: linkRichMenuIdToUsers
-      description: "Link rich menu to multiple users"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RichMenuBulkLinkRequest"
-        required: true
-      responses:
-        "202":
-          description: "Accepted"
-
-  "/v2/bot/richmenu/bulk/unlink":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-users
-      tags:
-        - messaging-api
-      operationId: unlinkRichMenuIdFromUsers
-      description: "Unlink rich menus from multiple users"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RichMenuBulkUnlinkRequest"
-        required: true
-      responses:
-        "202":
-          description: "Accepted"
-
   "/v2/bot/richmenu/list":
     get:
       externalDocs:
@@ -961,6 +1291,7 @@ paths:
                           type: postback
                           data: action=buy&itemid=123
 
+  # Default RichMenu
   "/v2/bot/user/all/richmenu/{richMenuId}":
     post:
       externalDocs:
@@ -1008,167 +1339,7 @@ paths:
         "200":
           description: "OK"
 
-  "/v2/bot/user/{userId}/linkToken":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#issue-link-token
-      tags:
-        - messaging-api
-      operationId: issueLinkToken
-      description: "Issue link token"
-      parameters:
-        - name: userId
-          in: path
-          required: true
-          schema:
-            type: string
-          description: |+
-            User ID for the LINE account to be linked.
-            Found in the `source` object of account link event objects. Do not use the LINE ID used in LINE.
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/IssueLinkTokenResponse"
-              example:
-                linkToken: NMZTNuVrPTqlr2IF8Bnymkb7rXfYv5EY
-
-  "/v2/bot/followers/ids":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
-      tags:
-        - messaging-api
-      operationId: getFollowers
-      description: "Get a list of users who added your LINE Official Account as a friend"
-      parameters:
-        - name: start
-          in: query
-          required: false
-          description: |+
-            Value of the continuation token found in the next property of the JSON object returned in the response.
-            Include this parameter to get the next array of user IDs.
-          schema:
-            type: string
-        - name: limit
-          in: query
-          required: false
-          description: "The maximum number of user IDs to retrieve in a single request."
-          schema:
-            type: integer
-            format: int32
-            default: 300
-            maximum: 1000
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/GetFollowersResponse"
-              example:
-                userIds:
-                  - U4af4980629...
-                  - U0c229f96c4...
-                  - U95afb1d4df...
-                next: yANU9IA...
-
-  "/v2/bot/info":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-bot-info
-      tags:
-        - messaging-api
-      operationId: getBotInfo
-      description: "Get bot info"
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/BotInfoResponse"
-              example:
-                userId: Ub9952f8...
-                basicId: "@216ru..."
-                displayName: Example name
-                pictureUrl: https://obs.line-apps.com/...
-                chatMode: chat
-                markAsReadMode: manual
-
-  "/v2/bot/channel/webhook/endpoint":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
-      tags:
-        - messaging-api
-      operationId: getWebhookEndpoint
-      description: "Get webhook endpoint information"
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/GetWebhookEndpointResponse"
-              examples:
-                ACTIVE:
-                  summary: "If the webhook URL was set and the webhook usage is enabled"
-                  value:
-                    endpoint: https://example.com/test
-                    active: true
-                INACTIVE:
-                  summary: "If the webhook URL was set and the webhook usage is disabled"
-                  value:
-                    endpoint: https://example.com/test
-                    active: false
-
-    put:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
-      tags:
-        - messaging-api
-      operationId: setWebhookEndpoint
-      description: "Set webhook endpoint URL"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/SetWebhookEndpointRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/channel/webhook/test":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
-      tags:
-        - messaging-api
-      operationId: testWebhookEndpoint
-      description: "Test webhook endpoint"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/TestWebhookEndpointRequest"
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/TestWebhookEndpointResponse"
-              example:
-                success: true
-                timestamp: "2020-09-30T05:38:20.031Z"
-                statusCode: 200
-                reason: OK
-                detail: "200"
-
+  # RichMenu Alias
   "/v2/bot/richmenu/alias":
     post:
       externalDocs:
@@ -1298,153 +1469,134 @@ paths:
                 NO_ALIASES:
                   summary: "If you have 0 rich menu alias"
                   value:
-                    aliases: []
+                    aliases: [ ]
 
-  "/v2/bot/message/aggregation/info":
+  # User RichMenu
+  "/v2/bot/user/{userId}/richmenu":
+    parameters:
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "User ID. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
     get:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-number-of-units-used-this-month
+        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-id-of-user
       tags:
         - messaging-api
-      operationId: getAggregationUnitUsage
-      description: "Get number of units used this month"
+      operationId: getRichMenuIdOfUser
+      description: "Get rich menu ID of user"
       responses:
         "200":
           description: "OK"
           content:
             "application/json":
               schema:
-                "$ref": "#/components/schemas/GetAggregationUnitUsageResponse"
+                "$ref": "#/components/schemas/RichMenuIdResponse"
               example:
-                numOfCustomAggregationUnits: 22
-
-  "/v2/bot/message/aggregation/list":
-    get:
+                "richMenuId": "{richMenuId}"
+    delete:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-name-list-of-units-used-this-month
+        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-user
       tags:
         - messaging-api
-      operationId: getAggregationUnitNameList
-      description: "Get name list of units used this month"
+      operationId: unlinkRichMenuIdFromUser
+      description: "Unlink rich menu from user"
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/user/{userId}/richmenu/{richMenuId}":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-user
+      tags:
+        - messaging-api
+      operationId: linkRichMenuIdToUser
+      description: "Link rich menu to user."
       parameters:
-        - name: limit
-          in: query
-          required: false
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "User ID. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
+        - name: richMenuId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "ID of a rich menu"
+      responses:
+        "200":
+          description: "OK"
+
+  "/v2/bot/richmenu/bulk/link":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-users
+      tags:
+        - messaging-api
+      operationId: linkRichMenuIdToUsers
+      description: "Link rich menu to multiple users"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RichMenuBulkLinkRequest"
+        required: true
+      responses:
+        "202":
+          description: "Accepted"
+
+  "/v2/bot/richmenu/bulk/unlink":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-users
+      tags:
+        - messaging-api
+      operationId: unlinkRichMenuIdFromUsers
+      description: "Unlink rich menus from multiple users"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RichMenuBulkUnlinkRequest"
+        required: true
+      responses:
+        "202":
+          description: "Accepted"
+
+  # Account link
+  "/v2/bot/user/{userId}/linkToken":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#issue-link-token
+      tags:
+        - messaging-api
+      operationId: issueLinkToken
+      description: "Issue link token"
+      parameters:
+        - name: userId
+          in: path
+          required: true
           schema:
             type: string
           description: |+
-            The maximum number of aggregation units you can get per request.
-        - name: start
-          in: query
-          required: false
-          schema:
-            type: string
-          description: |+
-            Value of the continuation token found in the next property of the JSON object returned in the response.
-            If you can't get all the aggregation units in one request, include this parameter to get the remaining array.
+            User ID for the LINE account to be linked.
+            Found in the `source` object of account link event objects. Do not use the LINE ID used in LINE.
       responses:
         "200":
           description: "OK"
           content:
             "application/json":
               schema:
-                "$ref": "#/components/schemas/GetAggregationUnitNameListResponse"
+                "$ref": "#/components/schemas/IssueLinkTokenResponse"
               example:
-                customAggregationUnits:
-                  - promotion_a
-                  - promotion_b
-                next: jxEWCEEP...
+                linkToken: NMZTNuVrPTqlr2IF8Bnymkb7rXfYv5EY
 
-  "/v2/bot/message/validate/reply":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-reply-message
-      tags:
-        - messaging-api
-      operationId: validateReply
-      description: "Validate message objects of a reply message"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ValidateMessageRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/message/validate/push":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-push-message
-      tags:
-        - messaging-api
-      operationId: validatePush
-      description: "Validate message objects of a push message"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ValidateMessageRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/message/validate/multicast":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-multicast-message
-      tags:
-        - messaging-api
-      operationId: validateMulticast
-      description: "Validate message objects of a multicast message"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ValidateMessageRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/message/validate/narrowcast":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-narrowcast-message
-      tags:
-        - messaging-api
-      operationId: validateNarrowcast
-      description: "Validate message objects of a narrowcast message"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ValidateMessageRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/message/validate/broadcast":
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#validate-message-objects-of-broadcast-message
-      tags:
-        - messaging-api
-      operationId: validateBroadcast
-      description: "Validate message objects of a broadcast message"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ValidateMessageRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-
+  # Optional APIs
   "/v2/bot/message/markAsRead":
     post:
       externalDocs:
@@ -1585,143 +1737,6 @@ paths:
                   summary: "Example response when status is `unavailable_for_privacy`"
                   value:
                     status: unavailable_for_privacy
-
-  "/v2/bot/message/{messageId}/content":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-content
-      servers:
-        - url: "https://api-data.line.me"
-      tags:
-        - messaging-api-blob
-      operationId: getMessageContent
-      description: "Download image, video, and audio data sent from users."
-      parameters:
-        - name: messageId
-          in: path
-          required: true
-          description: "Message ID of video or audio"
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "*/*":
-              schema:
-                description: "blob response"
-                type: string
-                format: binary
-
-  "/v2/bot/message/{messageId}/content/preview":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-image-or-video-preview
-      servers:
-        - url: "https://api-data.line.me"
-      tags:
-        - messaging-api-blob
-      operationId: getMessageContentPreview
-      description: "Get a preview image of the image or video"
-      parameters:
-        - name: messageId
-          in: path
-          required: true
-          description: "Message ID of image or video"
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "*/*":
-              schema:
-                type: string
-                format: binary
-                description: "blob response"
-
-  "/v2/bot/richmenu/{richMenuId}/content":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#download-rich-menu-image
-      servers:
-        - url: "https://api-data.line.me"
-      tags:
-        - messaging-api-blob
-      operationId: getRichMenuImage
-      description: "Download rich menu image."
-      parameters:
-        - name: richMenuId
-          in: path
-          required: true
-          description: "ID of the rich menu with the image to be downloaded"
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "OK"
-          content:
-            # TODO check the content-type of the actual implementation and replace here.
-            "*/*":
-              schema:
-                type: string
-                format: binary
-                description: "blob response"
-
-    post:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#upload-rich-menu-image
-      servers:
-        - url: "https://api-data.line.me"
-      tags:
-        - messaging-api-blob
-      operationId: setRichMenuImage
-      description: "Upload rich menu image"
-      parameters:
-        - name: richMenuId
-          in: path
-          required: true
-          description: "The ID of the rich menu to attach the image to"
-          schema:
-            type: string
-      requestBody:
-        content:
-          "*/*":
-            schema:
-              description: "blob request"
-              type: string
-              format: binary
-      responses:
-        "200":
-          description: "OK"
-
-  "/v2/bot/message/{messageId}/content/transcoding":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#verify-video-or-audio-preparation-status
-      servers:
-        - url: "https://api-data.line.me"
-      tags:
-        - messaging-api-blob
-      operationId: getMessageContentTranscodingByMessageId
-      description: "Verify the preparation status of a video or audio for getting"
-      parameters:
-        - name: messageId
-          in: path
-          required: true
-          description: "Message ID of video or audio"
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/GetMessageContentTranscodingResponse"
-              example:
-                status: processing
-
 
 components:
   securitySchemes:

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -869,7 +869,7 @@ paths:
           content:
             "application/json":
               schema:
-                "$ref": "#/components/schemas/UserProfileResponse" # TODO: languageはこのAPIからは取得できないけど大丈夫？
+                "$ref": "#/components/schemas/UserProfileResponse"
               example:
                   "displayName": "LINE taro"
                   "userId": "U4af4980629..."
@@ -902,7 +902,7 @@ paths:
           content:
             "application/json":
               schema:
-                "$ref": "#/components/schemas/UserProfileResponse" # TODO: languageはこのAPIからは取得できないけど大丈夫？
+                "$ref": "#/components/schemas/UserProfileResponse"
               example:
                 displayName: LINE taro
                 userId: U4af4980629...
@@ -1746,6 +1746,26 @@ components:
       description: "Channel access token"
 
   schemas:
+    # Webhook
+    GetWebhookEndpointResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
+      required:
+        - endpoint
+        - active
+      type: object
+      properties:
+        endpoint:
+          type: string
+          format: uri
+          description: "Webhook URL"
+        active:
+          type: boolean
+          description: |+
+            Webhook usage status. Send a webhook event from the LINE Platform to the webhook URL only if enabled.
+
+            `true`: Webhook usage is enabled.
+            `false`: Webhook usage is disabled.
     SetWebhookEndpointRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
@@ -1759,1226 +1779,69 @@ components:
           type: string
           format: uri
           description: "A valid webhook URL."
-    IssueLinkTokenResponse:
+    TestWebhookEndpointRequest:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#issue-link-token
-      required:
-        - linkToken
+        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
       type: object
       properties:
-        linkToken:
-          type: string
-          description: |+
-            Link token.
-            Link tokens are valid for 10 minutes and can only be used once.
-    Action:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#action-objects
-      description: "Action"
-      type: object
-      properties:
-        type:
-          type: string
-          description: "Type of action"
-        label:
-          type: string
-          description: "Label for the action."
-      discriminator:
-        propertyName: type
-        mapping:
-          camera: "#/components/schemas/CameraAction"
-          cameraRoll: "#/components/schemas/CameraRollAction"
-          datetimepicker: "#/components/schemas/DatetimePickerAction"
-          location: "#/components/schemas/LocationAction"
-          message: "#/components/schemas/MessageAction"
-          postback: "#/components/schemas/PostbackAction"
-          richmenuswitch: "#/components/schemas/RichMenuSwitchAction"
-          uri: "#/components/schemas/URIAction"
-    AltUri:
-      type: object
-      properties:
-        desktop:
-          maxLength: 1000
+        endpoint:
+          maxLength: 500
           minLength: 0
           type: string
-    RichMenuArea:
-      type: object
-      description: "Rich menu area"
-      properties:
-        bounds:
-          "$ref": "#/components/schemas/RichMenuBounds"
-        action:
-          "$ref": "#/components/schemas/Action"
-    RichMenuBounds:
+          format: uri
+          description: "A webhook URL to be validated."
+    TestWebhookEndpointResponse:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#bounds-object
-      type: object
-      description: "Rich menu bounds"
-      properties:
-        x:
-          maximum: 2147483647
-          minimum: 0
-          type: integer
-          format: int64
-          description: "Horizontal position relative to the top-left corner of the area."
-        y:
-          maximum: 2147483647
-          minimum: 0
-          type: integer
-          format: int64
-          description: "Vertical position relative to the top-left corner of the area."
-        width:
-          maximum: 2147483647
-          minimum: 1
-          type: integer
-          format: int64
-          description: "Width of the area."
-        height:
-          maximum: 2147483647
-          minimum: 1
-          type: integer
-          format: int64
-          description: "Height of the area."
-    CameraAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-    CameraRollAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-    DatetimePickerAction:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#datetime-picker-action
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-        - type: object
-          properties:
-            data:
-              maxLength: 300
-              minLength: 0
-              type: string
-            mode:
-              type: string
-              enum:
-                - date
-                - time
-                - datetime
-            initial:
-              type: string
-            max:
-              type: string
-            min:
-              type: string
-    LocationAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-    MessageAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-        - type: object
-          properties:
-            text:
-              type: string
-    PostbackAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-        - type: object
-          properties:
-            data:
-              maxLength: 300
-              minLength: 0
-              type: string
-            displayText:
-              type: string
-            text:
-              type: string
-            inputOption:
-              type: string
-              enum:
-                - closeRichMenu
-                - openRichMenu
-                - openKeyboard
-                - openVoice
-            fillInText:
-              type: string
-    RichMenuRequest:
+        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
+      required:
+        - statusCode
+        - timestamp
+        - reason
+        - detail
       type: object
       properties:
-        size:
-          "$ref": "#/components/schemas/RichMenuSize"
-        selected:
+        success:
           type: boolean
-          description: "`true` to display the rich menu by default. Otherwise, `false`."
-        name:
+          description: "Result of the communication from the LINE platform to the webhook URL."
+        timestamp:
           type: string
-          description: "Name of the rich menu. This value can be used to help manage your rich menus and is not displayed to users."
-          maxLength: 300
-        chatBarText:
-          type: string
-          description: "Text displayed in the chat bar"
-          maxLength: 14
-        areas:
-          type: array
-          description: "Array of area objects which define the coordinates and size of tappable areas"
-          items:
-            "$ref": "#/components/schemas/RichMenuArea"
-    RichMenuSize:
-      type: object
-      description: "Rich menu size"
-      properties:
-        width:
-          maximum: 2147483647
-          minimum: 1
-          type: integer
-          format: int64
-          description: "width"
-        height:
-          maximum: 2147483647
-          minimum: 1
-          type: integer
-          format: int64
-          description: "height"
-    RichMenuSwitchAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-        - type: object
-          properties:
-            data:
-              maxLength: 300
-              minLength: 0
-              type: string
-            richMenuAliasId:
-              maxLength: 32
-              minLength: 0
-              type: string
-    URIAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Action"
-        - type: object
-          properties:
-            uri:
-              type: string
-              format: uri
-            altUri:
-              "$ref": "#/components/schemas/AltUri"
-    RichMenuBulkUnlinkRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-users
-      required:
-        - userIds
-      type: object
-      properties:
-        userIds:
-          maxItems: 500
-          minItems: 1
-          type: array
-          items:
-            type: string
-          description: "Array of user IDs. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
-    RichMenuBulkLinkRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-users
-      required:
-        - richMenuId
-        - userIds
-      type: object
-      properties:
-        richMenuId:
-          type: string
-          description: "ID of a rich menu"
-        userIds:
-          maxItems: 500
-          minItems: 1
-          type: array
-          items:
-            type: string
-          description: "Array of user IDs. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
-    CreateRichMenuAliasRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#create-rich-menu-alias
-      required:
-        - richMenuAliasId
-        - richMenuId
-      type: object
-      properties:
-        richMenuAliasId:
-          type: string
-          description: "Rich menu alias ID, which can be any ID, unique for each channel."
-          maxLength: 32
-          minLength: 1
-          pattern: "^[a-z0-9_-]{1,32}$"
-        richMenuId:
-          type: string
-          description: "The rich menu ID to be associated with the rich menu alias."
-    UpdateRichMenuAliasRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#update-rich-menu-alias
-      required:
-        - richMenuId
-      type: object
-      properties:
-        richMenuId:
-          type: string
-          description: "The rich menu ID to be associated with the rich menu alias."
-    AudioMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            originalContentUrl:
-              type: string
-              format: uri
-            duration:
-              type: integer
-              format: int64
-    FlexBlockStyle:
-      type: object
-      properties:
-        backgroundColor:
-          type: string
-        separator:
-          type: boolean
-        separatorColor:
-          type: string
-    FlexBox:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - properties:
-            layout:
-              type: string
-              enum:
-                - horizontal
-                - vertical
-                - baseline
-            flex:
-              type: integer
-              format: int32
-            contents:
-              type: array
-              items:
-                "$ref": "#/components/schemas/FlexComponent"
-            spacing:
-              type: string
-            margin:
-              type: string
-            position:
-              type: string
-              enum:
-                - relative
-                - absolute
-            offsetTop:
-              type: string
-            offsetBottom:
-              type: string
-            offsetStart:
-              type: string
-            offsetEnd:
-              type: string
-            backgroundColor:
-              type: string
-            borderColor:
-              type: string
-            borderWidth:
-              type: string
-            cornerRadius:
-              type: string
-            width:
-              type: string
-            maxWidth:
-              type: string
-            height:
-              type: string
-            maxHeight:
-              type: string
-            paddingAll:
-              type: string
-            paddingTop:
-              type: string
-            paddingBottom:
-              type: string
-            paddingStart:
-              type: string
-            paddingEnd:
-              type: string
-            action:
-              "$ref": "#/components/schemas/Action"
-            justifyContent:
-              type: string
-              enum:
-                - center
-                - flex-start
-                - flex-end
-                - space-between
-                - space-around
-                - space-evenly
-            alignItems:
-              type: string
-              enum:
-                - center
-                - flex-start
-                - flex-end
-            background:
-              "$ref": "#/components/schemas/FlexBoxBackground"
-    FlexBoxBackground:
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          type: string
-      discriminator:
-        propertyName: type
-        mapping:
-          linearGradient: "#/components/schemas/FlexBoxLinearGradient"
-    FlexBoxLinearGradient:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexBoxBackground"
-        - type: object
-          properties:
-            angle:
-              type: string
-            startColor:
-              type: string
-            endColor:
-              type: string
-            centerColor:
-              type: string
-            centerPosition:
-              type: string
-    FlexBubbleStyles:
-      type: object
-      properties:
-        header:
-          "$ref": "#/components/schemas/FlexBlockStyle"
-        hero:
-          "$ref": "#/components/schemas/FlexBlockStyle"
-        body:
-          "$ref": "#/components/schemas/FlexBlockStyle"
-        footer:
-          "$ref": "#/components/schemas/FlexBlockStyle"
-    FlexButton:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            flex:
-              type: integer
-              format: int32
-            color:
-              type: string
-            style:
-              type: string
-              enum:
-                - primary
-                - secondary
-                - link
-            action:
-              "$ref": "#/components/schemas/Action"
-            gravity:
-              type: string
-              enum:
-                - top
-                - bottom
-                - center
-            margin:
-              type: string
-            position:
-              type: string
-              enum:
-                - relative
-                - absolute
-            offsetTop:
-              type: string
-            offsetBottom:
-              type: string
-            offsetStart:
-              type: string
-            offsetEnd:
-              type: string
-            height:
-              type: string
-              enum:
-                - md
-                - sm
-            adjustMode:
-              type: string
-              enum:
-                - shrink-to-fit
-    ButtonsTemplate:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Template"
-        - type: object
-          properties:
-            thumbnailImageUrl:
-              type: string
-              format: uri
-            imageAspectRatio:
-              type: string
-            imageSize:
-              type: string
-            imageBackgroundColor:
-              type: string
-            title:
-              type: string
-            text:
-              type: string
-            defaultAction:
-              "$ref": "#/components/schemas/Action"
-            actions:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Action"
-    CarouselColumn:
-      description: "Column object for carousel template."
-      type: object
-      properties:
-        thumbnailImageUrl:
-          type: string
-          format: uri
-        imageBackgroundColor:
-          type: string
-        title:
-          type: string
-        text:
-          type: string
-        defaultAction:
-          "$ref": "#/components/schemas/Action"
-        actions:
-          type: array
-          items:
-            "$ref": "#/components/schemas/Action"
-    CarouselTemplate:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Template"
-        - type: object
-          properties:
-            columns:
-              type: array
-              items:
-                "$ref": "#/components/schemas/CarouselColumn"
-            imageAspectRatio:
-              type: string
-            imageSize:
-              type: string
-    ConfirmTemplate:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Template"
-        - type: object
-          properties:
-            text:
-              type: string
-            actions:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Action"
-    Emoji:
-      type: object
-      properties:
-        index:
+          format: date-time
+          description: |+
+            Time of the event in milliseconds. Even in the case of a redelivered webhook, it represents the time the event occurred, not the time it was redelivered.
+        statusCode:
           type: integer
           format: int32
-        productId:
+          description: "The HTTP status code. If the webhook response isn't received, the status code is set to zero or a negative number."
+        reason:
           type: string
-        emojiId:
+          description: "Reason for the response."
+        detail:
           type: string
-    FlexFiller:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            flex:
-              type: integer
-              format: int32
-    FlexComponent:
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          type: string
-      discriminator:
-        propertyName: type
-        mapping:
-          box: "#/components/schemas/FlexBox"
-          button: "#/components/schemas/FlexButton"
-          image: "#/components/schemas/FlexImage"
-          video: "#/components/schemas/FlexVideo"
-          icon: "#/components/schemas/FlexIcon"
-          text: "#/components/schemas/FlexText"
-          span: "#/components/schemas/FlexSpan"
-          separator: "#/components/schemas/FlexSeparator"
-          filler: "#/components/schemas/FlexFiller"
-    FlexContainer:
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          type: string
-      discriminator:
-        propertyName: type
-        mapping:
-          bubble: "#/components/schemas/FlexBubble"
-          carousel: "#/components/schemas/FlexCarousel"
-    FlexBubble:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexContainer"
-        - type: object
-          properties:
-            direction:
-              type: string
-              enum:
-                - ltr
-                - rtl
-            styles:
-              "$ref": "#/components/schemas/FlexBubbleStyles"
-            header:
-              "$ref": "#/components/schemas/FlexBox"
-            hero:
-              "$ref": "#/components/schemas/FlexComponent"
-            body:
-              "$ref": "#/components/schemas/FlexBox"
-            footer:
-              "$ref": "#/components/schemas/FlexBox"
-            size:
-              type: string
-              enum:
-                - nano
-                - micro
-                - kilo
-                - mega
-                - giga
-            action:
-              "$ref": "#/components/schemas/Action"
-    FlexCarousel:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexContainer"
-        - type: object
-          properties:
-            contents:
-              type: array
-              items:
-                "$ref": "#/components/schemas/FlexBubble"
-    FlexMessage:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#flex-message
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            altText:
-              type: string
-            contents:
-              "$ref": "#/components/schemas/FlexContainer"
-    FlexIcon:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#icon
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            url:
-              type: string
-              format: uri
-            size:
-              type: string
-            aspectRatio:
-              type: string
-            margin:
-              type: string
-            position:
-              type: string
-              enum:
-                - relative
-                - absolute
-            offsetTop:
-              type: string
-            offsetBottom:
-              type: string
-            offsetStart:
-              type: string
-            offsetEnd:
-              type: string
-    FlexImage:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#f-image
-      type: object
-      required:
-        - type
-        - url
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            url:
-              type: string
-              format: uri
-              description: |+
-                Image URL (Max character limit: 2000)
-                Protocol: HTTPS (TLS 1.2 or later)
-                Image format: JPEG or PNG
-                Maximum image size: 1024×1024 pixels
-                Maximum file size: 10 MB (300 KB when the animated property is true)
-            flex:
-              type: integer
-              format: int32
-              description: "The ratio of the width or height of this component within the parent box."
-            margin:
-              type: string
-              description: |+
-                The minimum amount of space to include before this component in its parent container.
-            position:
-              type: string
-              enum:
-                - relative
-                - absolute
-              description: |+
-                Reference for offsetTop, offsetBottom, offsetStart, and offsetEnd. Specify one of the following values:
+          description: "Details of the response."
 
-                `relative`: Use the previous box as reference.
-                `absolute`: Use the top left of parent element as reference. The default value is relative.
-            offsetTop:
-              type: string
-              description: "Offset."
-            offsetBottom:
-              type: string
-              description: "Offset."
-            offsetStart:
-              type: string
-              description: "Offset."
-            offsetEnd:
-              type: string
-              description: "Offset."
-            align:
-              type: string
-              enum:
-                - start
-                - end
-                - center
-              description: |+
-                Alignment style in horizontal direction.
-            gravity:
-              type: string
-              enum:
-                - top
-                - bottom
-                - center
-              description: "Alignment style in vertical direction."
-            size:
-              type: string
-              default: md
-              description: |+
-                The maximum image width. This is md by default.
-            aspectRatio:
-              type: string
-              description: |+
-                Aspect ratio of the image.
-                `{width}:{height}` format.
-                Specify the value of `{width}` and `{height}` in the range from `1` to `100000`.
-                However, you cannot set `{height}` to a value that is more than three times the value of `{width}`.
-                The default value is `1:1`.
-            aspectMode:
-              type: string
-              enum:
-                - fit
-                - cover
-              description: |+
-                The display style of the image if the aspect ratio of the image and that specified by the aspectRatio property do not match.
-            backgroundColor:
-              type: string
-              description: "Background color of the image. Use a hexadecimal color code."
-            action:
-              "$ref": "#/components/schemas/Action"
-            animated:
-              type: boolean
-              default: false
-              description: |+
-                When this is `true`, an animated image (APNG) plays.
-                You can specify a value of true up to 10 images in a single message.
-                You can't send messages that exceed this limit. 
-                This is `false` by default.
-                Animated images larger than 300 KB aren't played back.
-    ImageCarouselColumn:
-      type: object
-      properties:
-        imageUrl:
-          type: string
-          format: uri
-        action:
-          "$ref": "#/components/schemas/Action"
-    ImageCarouselTemplate:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Template"
-        - type: object
-          properties:
-            columns:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ImageCarouselColumn"
-    ImageMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            originalContentUrl:
-              type: string
-              format: uri
-            previewImageUrl:
-              type: string
-              format: uri
-    ImagemapAction:
+    # Webhook content
+    GetMessageContentTranscodingResponse:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#imagemap-action-objects
+        url: https://developers.line.biz/en/reference/messaging-api/#verify-video-or-audio-preparation-status
+      description: "Transcoding response"
       required:
-        - type
+        - status
       type: object
       properties:
-        type:
+        status:
           type: string
-        area:
-          "$ref": "#/components/schemas/ImagemapArea"
-      discriminator:
-        propertyName: type
-        mapping:
-          message: "#/components/schemas/MessageImagemapAction"
-          uri: "#/components/schemas/URIImagemapAction"
-    MessageImagemapAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/ImagemapAction"
-        - type: object
-          properties:
-            text:
-              type: string
-            label:
-              type: string
-    URIImagemapAction:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/ImagemapAction"
-        - type: object
-          properties:
-            linkUri:
-              type: string
-            label:
-              type: string
-    ImagemapArea:
-      type: object
-      properties:
-        x:
-          type: integer
-          format: int32
-        y:
-          type: integer
-          format: int32
-        width:
-          type: integer
-          format: int32
-        height:
-          type: integer
-          format: int32
-    ImagemapBaseSize:
-      type: object
-      properties:
-        height:
-          type: integer
-          format: int32
-        width:
-          type: integer
-          format: int32
-    ImagemapExternalLink:
-      type: object
-      properties:
-        linkUri:
-          type: string
-          format: uri
-        label:
-          type: string
-    ImagemapMessage:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#imagemap-message
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            baseUrl:
-              type: string
-              format: uri
-            altText:
-              type: string
-            baseSize:
-              "$ref": "#/components/schemas/ImagemapBaseSize"
-            actions:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ImagemapAction"
-            video:
-              "$ref": "#/components/schemas/ImagemapVideo"
-    ImagemapVideo:
-      type: object
-      properties:
-        originalContentUrl:
-          type: string
-          format: uri
-        previewImageUrl:
-          type: string
-          format: uri
-        area:
-          "$ref": "#/components/schemas/ImagemapArea"
-        externalLink:
-          "$ref": "#/components/schemas/ImagemapExternalLink"
-    LocationMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            title:
-              type: string
-            address:
-              type: string
-            latitude:
-              type: number
-              format: double
-            longitude:
-              type: number
-              format: double
-    Message:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#message-common-properties
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          type: string
-          description: "Type of message"
-        quickReply:
-          "$ref": "#/components/schemas/QuickReply"
-        sender:
-          "$ref": "#/components/schemas/Sender"
-      discriminator:
-        propertyName: type
-        mapping:
-          text: "#/components/schemas/TextMessage"
-          sticker: "#/components/schemas/StickerMessage"
-          image: "#/components/schemas/ImageMessage"
-          video: "#/components/schemas/VideoMessage"
-          audio: "#/components/schemas/AudioMessage"
-          location: "#/components/schemas/LocationMessage"
-          imagemap: "#/components/schemas/ImagemapMessage"
-          template: "#/components/schemas/TemplateMessage"
-          flex: "#/components/schemas/FlexMessage"
-    QuickReply:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#items-object
-      type: object
-      description: "Quick reply"
-      properties:
-        items:
-          type: array
-          maxItems: 13
-          items:
-            "$ref": "#/components/schemas/QuickReplyItem"
-          description: "Quick reply button objects."
-    QuickReplyItem:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#items-object
-      type: object
-      properties:
-        imageUrl:
-          type: string
-          format: uri
-          description: "URL of the icon that is displayed at the beginning of the button"
-          maxLength: 2000
-        action:
-          "$ref": "#/components/schemas/Action"
-        type:
-          type: string
-          description: "`action`"
-          default: "action"
-    Sender:
-      type: object
-      description: "Change icon and display name"
-      properties:
-        name:
-          type: string
-          description: "Display name. Certain words such as `LINE` may not be used."
-          maxLength: 20
-        iconUrl:
-          type: string
-          format: uri
-          description: "URL of the image to display as an icon when sending a message"
-          maxLength: 2000
-    FlexSeparator:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            margin:
-              type: string
-            color:
-              type: string
-    FlexSpacer:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            size:
-              type: string
-              enum:
-                - default
-                - none
-                - xs
-                - sm
-                - md
-                - lg
-                - xl
-                - xxl
-    FlexSpan:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            text:
-              type: string
-            size:
-              type: string
-            color:
-              type: string
-            weight:
-              type: string
-              enum:
-                - regular
-                - bold
-            style:
-              type: string
-              enum:
-                - normal
-                - italic
-            decoration:
-              type: string
-              enum:
-                - none
-                - underline
-                - line-through
-    StickerMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            packageId:
-              type: string
-            stickerId:
-              type: string
-    Template:
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          type: string
-      discriminator:
-        propertyName: type
-        mapping:
-          buttons: "#/components/schemas/ButtonsTemplate"
-          confirm: "#/components/schemas/ConfirmTemplate"
-          carousel: "#/components/schemas/CarouselTemplate"
-          image_carousel: "#/components/schemas/ImageCarouselTemplate"
-    TemplateMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            altText:
-              type: string
-            template:
-              "$ref": "#/components/schemas/Template"
-    FlexText:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            flex:
-              type: integer
-              format: int32
-            text:
-              type: string
-            size:
-              type: string
-            align:
-              type: string
-              enum:
-                - start
-                - end
-                - center
-            gravity:
-              type: string
-              enum:
-                - top
-                - bottom
-                - center
-            color:
-              type: string
-            weight:
-              type: string
-              enum:
-                - regular
-                - bold
-            style:
-              type: string
-              enum:
-                - normal
-                - italic
-            decoration:
-              type: string
-              enum:
-                - none
-                - underline
-                - line-through
-            wrap:
-              type: boolean
-            lineSpacing:
-              type: string
-            margin:
-              type: string
-            position:
-              type: string
-              enum:
-                - relative
-                - absolute
-            offsetTop:
-              type: string
-            offsetBottom:
-              type: string
-            offsetStart:
-              type: string
-            offsetEnd:
-              type: string
-            action:
-              "$ref": "#/components/schemas/Action"
-            maxLines:
-              type: integer
-              format: int32
-            contents:
-              type: array
-              items:
-                "$ref": "#/components/schemas/FlexSpan"
-            adjustMode:
-              type: string
-              enum:
-                - shrink-to-fit
-    TextMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            text:
-              type: string
-            emojis:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Emoji"
-    ValidateMessageRequest:
-      required:
-        - messages
-      type: object
-      properties:
-        messages:
-          maxItems: 5
-          minItems: 1
-          type: array
-          items:
-            "$ref": "#/components/schemas/Message"
-          description: "Array of message objects to validate"
+          description: |+
+            The preparation status. One of:
 
-    FlexVideo:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            url:
-              type: string
-              format: uri
-            previewUrl:
-              type: string
-              format: uri
-            altContent:
-              "$ref": "#/components/schemas/FlexComponent"
-            aspectRatio:
-              type: string
-            action:
-              "$ref": "#/components/schemas/Action"
-    VideoMessage:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Message"
-        - type: object
-          properties:
-            originalContentUrl:
-              type: string
-              format: uri
-            previewImageUrl:
-              type: string
-              format: uri
-            trackingId:
-              type: string
+            `processing`: Preparing to get content.
+            `succeeded`: Ready to get the content. You can get the content sent by users.
+            `failed`: Failed to prepare to get the content.
+          enum:
+            - processing
+            - succeeded
+            - failed
 
-    ErrorResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#error-responses
-      type: object
-      required:
-        - message
-      properties:
-        message:
-          type: string
-          description: "Message containing information about the error."
-        details:
-          type: array
-          items:
-            $ref: "#/components/schemas/ErrorDetail"
-          description: "An array of error details. If the array is empty, this property will not be included in the response."
-    ErrorDetail:
-      type: object
-      properties:
-        message:
-          type: string
-          description: "Details of the error. Not included in the response under certain situations."
-        property:
-          type: string
-          description: "Location of where the error occurred. Returns the JSON field name or query parameter name of the request. Not included in the response under certain situations."
-
+    # Messaging
     ReplyMessageRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#send-reply-message
@@ -3026,6 +1889,141 @@ components:
           type: array
           items:
             type: string
+    NotificationDisabled:
+      type: boolean
+      default: false
+      description: |+
+        `true`: The user doesn’t receive a push notification when a message is sent.
+        `false`: The user receives a push notification when the message is sent (unless they have disabled push notifications in LINE and/or their device).
+        The default value is false.
+    MulticastRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
+      required:
+        - messages
+        - to
+      type: object
+      properties:
+        messages:
+          maxItems: 5
+          minItems: 1
+          type: array
+          description: "Messages to send"
+          items:
+            "$ref": "#/components/schemas/Message"
+        to:
+          maxItems: 500
+          minItems: 1
+          type: array
+          description: "Array of user IDs. Use userId values which are returned in webhook event objects. Do not use LINE IDs found on LINE."
+          items:
+            type: string
+        notificationDisabled:
+          "$ref": "#/components/schemas/NotificationDisabled"
+        customAggregationUnits:
+          type: array
+          maxItems: 1
+          description: "Name of aggregation unit. Case-sensitive."
+          items:
+            type: string
+            maxLength: 30
+            minLength: 1
+            pattern: "^[a-zA-Z0-9_]{1,30}$"
+    NarrowcastRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
+      required:
+        - messages
+      type: object
+      properties:
+        messages:
+          maxItems: 5
+          minItems: 1
+          type: array
+          items:
+            "$ref": "#/components/schemas/Message"
+          description: "List of Message objects."
+        recipient:
+          "$ref": "#/components/schemas/Recipient"
+        filter:
+          "$ref": "#/components/schemas/Filter"
+        limit:
+          "$ref": "#/components/schemas/Limit"
+        notificationDisabled:
+          "$ref": "#/components/schemas/NotificationDisabled"
+    Recipient:
+      type: object
+      description: "Recipient"
+      properties:
+        type:
+          description: "Type of recipient"
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          operator: "#/components/schemas/OperatorRecipient"
+          audience: "#/components/schemas/AudienceRecipient"
+          redelivery: "#/components/schemas/RedeliveryRecipient"
+    OperatorRecipient:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Recipient"
+        - type: object
+          properties:
+            and:
+              type: array
+              items:
+                "$ref": "#/components/schemas/Recipient"
+              description: |+
+                Create a new recipient object by taking the logical conjunction (AND) of the specified array of recipient objects.
+            or:
+              type: array
+              items:
+                "$ref": "#/components/schemas/Recipient"
+              description: |+
+                Create a new recipient object by taking the logical disjunction (OR) of the specified array of recipient objects.
+            not:
+              # Create a new recipient object that excludes the specified recipient object.
+              "$ref": "#/components/schemas/Recipient"
+    AudienceRecipient:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Recipient"
+        - type: object
+          properties:
+            audienceGroupId:
+              type: integer
+              format: int64
+    RedeliveryRecipient:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Recipient"
+        - type: object
+          properties:
+            requestId:
+              type: string
+    Filter:
+      type: object
+      description: "Filter for narrowcast"
+      properties:
+        demographic:
+          $ref: "#/components/schemas/DemographicFilter"
+    DemographicFilter:
+      type: object
+      description: "Demographic filter"
+      properties:
+        type:
+          type: string
+          description: "Type of demographic filter"
+      discriminator:
+        propertyName: type
+        mapping:
+          age: "#/components/schemas/AgeDemographicFilter"
+          appType: "#/components/schemas/AppTypeDemographicFilter"
+          area: "#/components/schemas/AreaDemographicFilter"
+          gender: "#/components/schemas/GenderDemographicFilter"
+          operator: "#/components/schemas/OperatorDemographicFilter"
+          subscriptionPeriod: "#/components/schemas/SubscriptionPeriodDemographicFilter"
     AgeDemographicFilter:
       type: object
       allOf:
@@ -3346,37 +2344,6 @@ components:
         - "id_11: スラバヤ // Surabaya"
         - "id_12: ジョグジャカルタ // Yogyakarta"
         - "id_05: その他のエリア // Lainnya"
-    AudienceRecipient:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Recipient"
-        - type: object
-          properties:
-            audienceGroupId:
-              type: integer
-              format: int64
-    DemographicFilter:
-      type: object
-      description: "Demographic filter"
-      properties:
-        type:
-          type: string
-          description: "Type of demographic filter"
-      discriminator:
-        propertyName: type
-        mapping:
-          age: "#/components/schemas/AgeDemographicFilter"
-          appType: "#/components/schemas/AppTypeDemographicFilter"
-          area: "#/components/schemas/AreaDemographicFilter"
-          gender: "#/components/schemas/GenderDemographicFilter"
-          operator: "#/components/schemas/OperatorDemographicFilter"
-          subscriptionPeriod: "#/components/schemas/SubscriptionPeriodDemographicFilter"
-    Filter:
-      type: object
-      description: "Filter for narrowcast"
-      properties:
-        demographic:
-          $ref: "#/components/schemas/DemographicFilter"
     GenderDemographicFilter:
       type: object
       allOf:
@@ -3392,6 +2359,40 @@ components:
       enum:
         - male
         - female
+    OperatorDemographicFilter:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/DemographicFilter"
+        - type: object
+          properties:
+            and:
+              type: array
+              items:
+                "$ref": "#/components/schemas/DemographicFilter"
+            or:
+              type: array
+              items:
+                "$ref": "#/components/schemas/DemographicFilter"
+            not:
+              "$ref": "#/components/schemas/DemographicFilter"
+    SubscriptionPeriodDemographicFilter:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/DemographicFilter"
+        - type: object
+          properties:
+            gte:
+              "$ref": "#/components/schemas/SubscriptionPeriodDemographic"
+            lt:
+              "$ref": "#/components/schemas/SubscriptionPeriodDemographic"
+    SubscriptionPeriodDemographic:
+      type: string
+      enum:
+        - day_7
+        - day_30
+        - day_90
+        - day_180
+        - day_365
     Limit:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
@@ -3413,332 +2414,6 @@ components:
             If true, the message will be sent within the maximum number of deliverable messages. The default value is `false`.
 
             Targets will be selected at random.
-    NarrowcastRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
-      required:
-        - messages
-      type: object
-      properties:
-        messages:
-          maxItems: 5
-          minItems: 1
-          type: array
-          items:
-            "$ref": "#/components/schemas/Message"
-          description: "List of Message objects."
-        recipient:
-          "$ref": "#/components/schemas/Recipient"
-        filter:
-          "$ref": "#/components/schemas/Filter"
-        limit:
-          "$ref": "#/components/schemas/Limit"
-        notificationDisabled:
-          "$ref": "#/components/schemas/NotificationDisabled"
-    OperatorDemographicFilter:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/DemographicFilter"
-        - type: object
-          properties:
-            and:
-              type: array
-              items:
-                "$ref": "#/components/schemas/DemographicFilter"
-            or:
-              type: array
-              items:
-                "$ref": "#/components/schemas/DemographicFilter"
-            not:
-              "$ref": "#/components/schemas/DemographicFilter"
-    OperatorRecipient:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Recipient"
-        - type: object
-          properties:
-            and:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Recipient"
-              description: |+
-                Create a new recipient object by taking the logical conjunction (AND) of the specified array of recipient objects.
-            or:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Recipient"
-              description: |+
-                Create a new recipient object by taking the logical disjunction (OR) of the specified array of recipient objects.
-            not:
-              # Create a new recipient object that excludes the specified recipient object.
-              "$ref": "#/components/schemas/Recipient"
-    Recipient:
-      type: object
-      description: "Recipient"
-      properties:
-        type:
-          description: "Type of recipient"
-          type: string
-      discriminator:
-        propertyName: type
-        mapping:
-          operator: "#/components/schemas/OperatorRecipient"
-          audience: "#/components/schemas/AudienceRecipient"
-          redelivery: "#/components/schemas/RedeliveryRecipient"
-    RedeliveryRecipient:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/Recipient"
-        - type: object
-          properties:
-            requestId:
-              type: string
-    SubscriptionPeriodDemographicFilter:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/DemographicFilter"
-        - type: object
-          properties:
-            gte:
-              "$ref": "#/components/schemas/SubscriptionPeriodDemographic"
-            lt:
-              "$ref": "#/components/schemas/SubscriptionPeriodDemographic"
-    SubscriptionPeriodDemographic:
-      type: string
-      enum:
-        - day_7
-        - day_30
-        - day_90
-        - day_180
-        - day_365
-    MulticastRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
-      required:
-        - messages
-        - to
-      type: object
-      properties:
-        messages:
-          maxItems: 5
-          minItems: 1
-          type: array
-          description: "Messages to send"
-          items:
-            "$ref": "#/components/schemas/Message"
-        to:
-          maxItems: 500
-          minItems: 1
-          type: array
-          description: "Array of user IDs. Use userId values which are returned in webhook event objects. Do not use LINE IDs found on LINE."
-          items:
-            type: string
-        notificationDisabled:
-          "$ref": "#/components/schemas/NotificationDisabled"
-        customAggregationUnits:
-          type: array
-          maxItems: 1
-          description: "Name of aggregation unit. Case-sensitive."
-          items:
-            type: string
-            maxLength: 30
-            minLength: 1
-            pattern: "^[a-zA-Z0-9_]{1,30}$"
-    BroadcastRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
-      required:
-        - messages
-      type: object
-      properties:
-        messages:
-          maxItems: 5
-          minItems: 1
-          type: array
-          items:
-            "$ref": "#/components/schemas/Message"
-          description: "List of Message objects."
-        notificationDisabled:
-          "$ref": "#/components/schemas/NotificationDisabled"
-    TestWebhookEndpointRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
-      type: object
-      properties:
-        endpoint:
-          maxLength: 500
-          minLength: 0
-          type: string
-          format: uri
-          description: "A webhook URL to be validated."
-    TestWebhookEndpointResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
-      required:
-        - statusCode
-        - timestamp
-        - reason
-        - detail
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: "Result of the communication from the LINE platform to the webhook URL."
-        timestamp:
-          type: string
-          format: date-time
-          description: |+
-            Time of the event in milliseconds. Even in the case of a redelivered webhook, it represents the time the event occurred, not the time it was redelivered.
-        statusCode:
-          type: integer
-          format: int32
-          description: "The HTTP status code. If the webhook response isn't received, the status code is set to zero or a negative number."
-        reason:
-          type: string
-          description: "Reason for the response."
-        detail:
-          type: string
-          description: "Details of the response."
-    RichMenuIdResponse:
-      # https://developers.line.biz/en/reference/messaging-api/#create-rich-menu
-      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-id-of-user
-      # https://developers.line.biz/en/reference/messaging-api/#get-default-rich-menu-id
-      required:
-        - richMenuId
-      type: object
-      properties:
-        richMenuId:
-          type: string
-          description: "Rich menu ID"
-    UserProfileResponse:
-      # https://developers.line.biz/en/reference/messaging-api/#get-profile
-      # https://developers.line.biz/en/reference/messaging-api/#get-group-member-profile
-      # https://developers.line.biz/en/reference/messaging-api/#get-room-member-profile
-      required:
-        - displayName
-        - userId
-      type: object
-      properties:
-        displayName:
-          type: string
-          description: "User's display name"
-        userId:
-          type: string
-          description: "User ID"
-        pictureUrl:
-          type: string
-          format: uri
-          description: "Profile image URL. `https` image URL. Not included in the response if the user doesn't have a profile image."
-        statusMessage:
-          type: string
-          description: "User's status message. Not included in the response if the user doesn't have a status message."
-        language:
-          type: string
-          description: "User's language, as a BCP 47 (opens new window)language tag. Not included in the response if the user hasn't yet consented to the LINE Privacy Policy."
-          example: en
-    RichMenuResponse:
-      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu
-      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-list
-      required:
-        - richMenuId
-        - size
-        - selected
-        - name
-        - chatBarText
-        - areas
-      type: object
-      properties:
-        richMenuId:
-          type: string
-          description: "ID of a rich menu"
-        size:
-          "$ref": "#/components/schemas/RichMenuSize"
-        selected:
-          type: boolean
-          description: "`true` to display the rich menu by default. Otherwise, `false`."
-        name:
-          type: string
-          description: "Name of the rich menu. This value can be used to help manage your rich menus and is not displayed to users."
-          maxLength: 300
-        chatBarText:
-          type: string
-          description: "Text displayed in the chat bar"
-          maxLength: 14
-        areas:
-          type: array
-          items:
-            "$ref": "#/components/schemas/RichMenuArea"
-          description: "Array of area objects which define the coordinates and size of tappable areas"
-          maxItems: 20
-    RichMenuListResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-list
-      required:
-        - richmenus
-      type: object
-      properties:
-        richmenus:
-          type: array
-          items:
-            "$ref": "#/components/schemas/RichMenuResponse"
-          description: "Rich menus"
-    RichMenuAliasListResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-alias-list
-      required:
-        - aliases
-      type: object
-      properties:
-        aliases:
-          type: array
-          items:
-            "$ref": "#/components/schemas/RichMenuAliasResponse"
-          description: "Rich menu aliases."
-    RichMenuAliasResponse:
-      required:
-        - richMenuAliasId
-        - richMenuId
-      type: object
-      properties:
-        richMenuAliasId:
-          type: string
-          description: "Rich menu alias ID."
-        richMenuId:
-          type: string
-          description: "The rich menu ID associated with the rich menu alias."
-    MessageQuotaResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-quota
-      required:
-        - type
-      type: object
-      properties:
-        type:
-          "$ref": "#/components/schemas/QuotaType"
-        value:
-          type: integer
-          format: int64
-          description: |+
-            The target limit for sending messages in the current month. This property is returned when the `type` property has a value of `limited`.
-    QuotaType:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-quota
-      type: string
-      enum:
-        - none
-        - limited
-      description: "One of the following values to indicate whether a target limit is set or not."
-    QuotaConsumptionResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-consumption
-      required:
-        - totalUsage
-      type: object
-      properties:
-        totalUsage:
-          type: integer
-          format: int64
-          description: "The number of sent messages in the current month"
     NarrowcastProgressResponse:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#get-narrowcast-progress-status
@@ -3802,6 +2477,59 @@ components:
 
             Format: ISO 8601 (opens new window)(e.g. 2020-12-03T10:15:30.121Z)
             Timezone: UTC
+    BroadcastRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
+      required:
+        - messages
+      type: object
+      properties:
+        messages:
+          maxItems: 5
+          minItems: 1
+          type: array
+          items:
+            "$ref": "#/components/schemas/Message"
+          description: "List of Message objects."
+        notificationDisabled:
+          "$ref": "#/components/schemas/NotificationDisabled"
+
+    # Quota
+    MessageQuotaResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-quota
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          "$ref": "#/components/schemas/QuotaType"
+        value:
+          type: integer
+          format: int64
+          description: |+
+            The target limit for sending messages in the current month. This property is returned when the `type` property has a value of `limited`.
+    QuotaType:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-quota
+      type: string
+      enum:
+        - none
+        - limited
+      description: "One of the following values to indicate whether a target limit is set or not."
+    QuotaConsumptionResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-consumption
+      required:
+        - totalUsage
+      type: object
+      properties:
+        totalUsage:
+          type: integer
+          format: int64
+          description: "The number of sent messages in the current month"
+
+    # Delivery
     NumberOfMessagesResponse:
       required:
         - status
@@ -3827,6 +2555,33 @@ components:
           description: |+
             The number of messages delivered using the phone number on the date specified in `date`.
             The response has this property only when the value of `status` is `ready`.
+
+    # Messaging validation
+    ValidateMessageRequest:
+      required:
+        - messages
+      type: object
+      properties:
+        messages:
+          maxItems: 5
+          minItems: 1
+          type: array
+          items:
+            "$ref": "#/components/schemas/Message"
+          description: "Array of message objects to validate"
+
+    # Aggregation Unit
+    GetAggregationUnitUsageResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-number-of-units-used-this-month
+      required:
+        - numOfCustomAggregationUnits
+      type: object
+      properties:
+        numOfCustomAggregationUnits:
+          type: integer
+          format: int64
+          description: "Number of aggregation units used this month."
     GetAggregationUnitNameListResponse:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#get-name-list-of-units-used-this-month
@@ -3844,17 +2599,58 @@ components:
           description: |+
             A continuation token to get the next array of unit names.
             Returned only when there are remaining aggregation units that weren't returned in customAggregationUnits in the original request.
-    GetAggregationUnitUsageResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-number-of-units-used-this-month
+
+    # Users
+    UserProfileResponse:
+      # TODO: Don't use it in group/room API. group/room profile doesn't contain statusMessage and language.
+      # https://developers.line.biz/en/reference/messaging-api/#get-profile
+      # https://developers.line.biz/en/reference/messaging-api/#get-group-member-profile
+      # https://developers.line.biz/en/reference/messaging-api/#get-room-member-profile
       required:
-        - numOfCustomAggregationUnits
+        - displayName
+        - userId
       type: object
       properties:
-        numOfCustomAggregationUnits:
-          type: integer
-          format: int64
-          description: "Number of aggregation units used this month."
+        displayName:
+          type: string
+          description: "User's display name"
+        userId:
+          type: string
+          description: "User ID"
+        pictureUrl:
+          type: string
+          format: uri
+          description: "Profile image URL. `https` image URL. Not included in the response if the user doesn't have a profile image."
+        statusMessage:
+          type: string
+          description: "User's status message. Not included in the response if the user doesn't have a status message."
+        language:
+          type: string
+          description: "User's language, as a BCP 47 (opens new window)language tag. Not included in the response if the user hasn't yet consented to the LINE Privacy Policy."
+          example: en
+    GetFollowersResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
+      required:
+        - userIds
+      type: object
+      properties:
+        userIds:
+          type: array
+          maxItems: 1000
+          description: |+
+            An array of strings indicating user IDs of users that have added the LINE Official Account as a friend.
+            Only users of LINE for iOS and LINE for Android are included in `userIds`.
+          items:
+            type: string
+        next:
+          type: string
+          description: |+
+            A continuation token to get the next array of user IDs.
+            Returned only when there are remaining user IDs that weren't returned in `userIds` in the original request.
+            The number of user IDs in the `userIds` element doesn't have to reach the maximum number specified by `limit` for the `next` property to be included in the response.
+
+    # Bot
     BotInfoResponse:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#get-bot-info
@@ -3902,25 +2698,8 @@ components:
 
             `auto`: Auto read setting is enabled.
             `manual`: Auto read setting is disabled.
-    GetWebhookEndpointResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
-      required:
-        - endpoint
-        - active
-      type: object
-      properties:
-        endpoint:
-          type: string
-          format: uri
-          description: "Webhook URL"
-        active:
-          type: boolean
-          description: |+
-            Webhook usage status. Send a webhook event from the LINE Platform to the webhook URL only if enabled.
 
-            `true`: Webhook usage is enabled.
-            `false`: Webhook usage is disabled.
+    # Group
     MembersIdsResponse:
       # https://developers.line.biz/en/reference/messaging-api/#get-group-member-user-ids
       # https://developers.line.biz/en/reference/messaging-api/#get-room-member-user-ids
@@ -3979,29 +2758,243 @@ components:
           type: integer
           format: int32
           description: "The count of members in the multi-person chat. The number returned excludes the LINE Official Account."
-    GetFollowersResponse:
+
+    # RichMenu
+    RichMenuRequest:
+      type: object
+      properties:
+        size:
+          "$ref": "#/components/schemas/RichMenuSize"
+        selected:
+          type: boolean
+          description: "`true` to display the rich menu by default. Otherwise, `false`."
+        name:
+          type: string
+          description: "Name of the rich menu. This value can be used to help manage your rich menus and is not displayed to users."
+          maxLength: 300
+        chatBarText:
+          type: string
+          description: "Text displayed in the chat bar"
+          maxLength: 14
+        areas:
+          type: array
+          description: "Array of area objects which define the coordinates and size of tappable areas"
+          items:
+            "$ref": "#/components/schemas/RichMenuArea"
+    RichMenuSize:
+      type: object
+      description: "Rich menu size"
+      properties:
+        width:
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          format: int64
+          description: "width"
+        height:
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          format: int64
+          description: "height"
+    RichMenuArea:
+      type: object
+      description: "Rich menu area"
+      properties:
+        bounds:
+          "$ref": "#/components/schemas/RichMenuBounds"
+        action:
+          "$ref": "#/components/schemas/Action"
+    RichMenuBounds:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
+        url: https://developers.line.biz/en/reference/messaging-api/#bounds-object
+      type: object
+      description: "Rich menu bounds"
+      properties:
+        x:
+          maximum: 2147483647
+          minimum: 0
+          type: integer
+          format: int64
+          description: "Horizontal position relative to the top-left corner of the area."
+        y:
+          maximum: 2147483647
+          minimum: 0
+          type: integer
+          format: int64
+          description: "Vertical position relative to the top-left corner of the area."
+        width:
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          format: int64
+          description: "Width of the area."
+        height:
+          maximum: 2147483647
+          minimum: 1
+          type: integer
+          format: int64
+          description: "Height of the area."
+    RichMenuIdResponse:
+      # https://developers.line.biz/en/reference/messaging-api/#create-rich-menu
+      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-id-of-user
+      # https://developers.line.biz/en/reference/messaging-api/#get-default-rich-menu-id
+      required:
+        - richMenuId
+      type: object
+      properties:
+        richMenuId:
+          type: string
+          description: "Rich menu ID"
+    RichMenuResponse:
+      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu
+      # https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-list
+      required:
+        - richMenuId
+        - size
+        - selected
+        - name
+        - chatBarText
+        - areas
+      type: object
+      properties:
+        richMenuId:
+          type: string
+          description: "ID of a rich menu"
+        size:
+          "$ref": "#/components/schemas/RichMenuSize"
+        selected:
+          type: boolean
+          description: "`true` to display the rich menu by default. Otherwise, `false`."
+        name:
+          type: string
+          description: "Name of the rich menu. This value can be used to help manage your rich menus and is not displayed to users."
+          maxLength: 300
+        chatBarText:
+          type: string
+          description: "Text displayed in the chat bar"
+          maxLength: 14
+        areas:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RichMenuArea"
+          description: "Array of area objects which define the coordinates and size of tappable areas"
+          maxItems: 20
+    RichMenuListResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-list
+      required:
+        - richmenus
+      type: object
+      properties:
+        richmenus:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RichMenuResponse"
+          description: "Rich menus"
+
+    # RichMenu Alias
+    CreateRichMenuAliasRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#create-rich-menu-alias
+      required:
+        - richMenuAliasId
+        - richMenuId
+      type: object
+      properties:
+        richMenuAliasId:
+          type: string
+          description: "Rich menu alias ID, which can be any ID, unique for each channel."
+          maxLength: 32
+          minLength: 1
+          pattern: "^[a-z0-9_-]{1,32}$"
+        richMenuId:
+          type: string
+          description: "The rich menu ID to be associated with the rich menu alias."
+    RichMenuAliasResponse:
+      required:
+        - richMenuAliasId
+        - richMenuId
+      type: object
+      properties:
+        richMenuAliasId:
+          type: string
+          description: "Rich menu alias ID."
+        richMenuId:
+          type: string
+          description: "The rich menu ID associated with the rich menu alias."
+    UpdateRichMenuAliasRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#update-rich-menu-alias
+      required:
+        - richMenuId
+      type: object
+      properties:
+        richMenuId:
+          type: string
+          description: "The rich menu ID to be associated with the rich menu alias."
+    RichMenuAliasListResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-alias-list
+      required:
+        - aliases
+      type: object
+      properties:
+        aliases:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RichMenuAliasResponse"
+          description: "Rich menu aliases."
+
+    # User RichMenu
+    RichMenuBulkLinkRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#link-rich-menu-to-users
+      required:
+        - richMenuId
+        - userIds
+      type: object
+      properties:
+        richMenuId:
+          type: string
+          description: "ID of a rich menu"
+        userIds:
+          maxItems: 500
+          minItems: 1
+          type: array
+          items:
+            type: string
+          description: "Array of user IDs. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
+    RichMenuBulkUnlinkRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#unlink-rich-menu-from-users
       required:
         - userIds
       type: object
       properties:
         userIds:
+          maxItems: 500
+          minItems: 1
           type: array
-          maxItems: 1000
-          description: |+
-            An array of strings indicating user IDs of users that have added the LINE Official Account as a friend.
-            Only users of LINE for iOS and LINE for Android are included in `userIds`.
           items:
             type: string
-        next:
+          description: "Array of user IDs. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE."
+
+    # Account link
+    IssueLinkTokenResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#issue-link-token
+      required:
+        - linkToken
+      type: object
+      properties:
+        linkToken:
           type: string
           description: |+
-            A continuation token to get the next array of user IDs.
-            Returned only when there are remaining user IDs that weren't returned in `userIds` in the original request.
-            The number of user IDs in the `userIds` element doesn't have to reach the maximum number specified by `limit` for the `next` property to be included in the response.
+            Link token.
+            Link tokens are valid for 10 minutes and can only be used once.
 
-
+    # Optional APIs
     MarkMessagesAsReadRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/partner-docs/#mark-messages-from-users-as-read
@@ -4022,7 +3015,6 @@ components:
         userId:
           type: string
           description: "The target user ID"
-
     PnpMessagesRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/partner-docs/#send-line-notification-message
@@ -4043,7 +3035,6 @@ components:
           description: "Message destination. Specify a phone number that has been normalized to E.164 format and hashed with SHA256."
         notificationDisabled:
           "$ref": "#/components/schemas/NotificationDisabled"
-
     AudienceMatchMessagesRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/partner-docs/#phone-audience-match
@@ -4068,31 +3059,1069 @@ components:
             type: string
         notificationDisabled:
           "$ref": "#/components/schemas/NotificationDisabled"
-    NotificationDisabled:
-      type: boolean
-      default: false
-      description: |+
-        `true`: The user doesn’t receive a push notification when a message is sent.
-        `false`: The user receives a push notification when the message is sent (unless they have disabled push notifications in LINE and/or their device).
-        The default value is false.
 
-    GetMessageContentTranscodingResponse:
+    # Message objects
+    Message:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#verify-video-or-audio-preparation-status
-      description: "Transcoding response"
+        url: https://developers.line.biz/en/reference/messaging-api/#message-common-properties
       required:
-        - status
+        - type
       type: object
       properties:
-        status:
+        type:
           type: string
-          description: |+
-            The preparation status. One of:
+          description: "Type of message"
+        quickReply:
+          "$ref": "#/components/schemas/QuickReply"
+        sender:
+          "$ref": "#/components/schemas/Sender"
+      discriminator:
+        propertyName: type
+        mapping:
+          text: "#/components/schemas/TextMessage"
+          sticker: "#/components/schemas/StickerMessage"
+          image: "#/components/schemas/ImageMessage"
+          video: "#/components/schemas/VideoMessage"
+          audio: "#/components/schemas/AudioMessage"
+          location: "#/components/schemas/LocationMessage"
+          imagemap: "#/components/schemas/ImagemapMessage"
+          template: "#/components/schemas/TemplateMessage"
+          flex: "#/components/schemas/FlexMessage"
+    QuickReply:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#items-object
+      type: object
+      description: "Quick reply"
+      properties:
+        items:
+          type: array
+          maxItems: 13
+          items:
+            "$ref": "#/components/schemas/QuickReplyItem"
+          description: "Quick reply button objects."
+    QuickReplyItem:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#items-object
+      type: object
+      properties:
+        imageUrl:
+          type: string
+          format: uri
+          description: "URL of the icon that is displayed at the beginning of the button"
+          maxLength: 2000
+        action:
+          "$ref": "#/components/schemas/Action"
+        type:
+          type: string
+          description: "`action`"
+          default: "action"
+    Sender:
+      type: object
+      description: "Change icon and display name"
+      properties:
+        name:
+          type: string
+          description: "Display name. Certain words such as `LINE` may not be used."
+          maxLength: 20
+        iconUrl:
+          type: string
+          format: uri
+          description: "URL of the image to display as an icon when sending a message"
+          maxLength: 2000
+    TextMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            text:
+              type: string
+            emojis:
+              type: array
+              items:
+                "$ref": "#/components/schemas/Emoji"
+    Emoji:
+      type: object
+      properties:
+        index:
+          type: integer
+          format: int32
+        productId:
+          type: string
+        emojiId:
+          type: string
+    StickerMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            packageId:
+              type: string
+            stickerId:
+              type: string
+    ImageMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            originalContentUrl:
+              type: string
+              format: uri
+            previewImageUrl:
+              type: string
+              format: uri
+    VideoMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            originalContentUrl:
+              type: string
+              format: uri
+            previewImageUrl:
+              type: string
+              format: uri
+            trackingId:
+              type: string
+    AudioMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            originalContentUrl:
+              type: string
+              format: uri
+            duration:
+              type: integer
+              format: int64
+    LocationMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            title:
+              type: string
+            address:
+              type: string
+            latitude:
+              type: number
+              format: double
+            longitude:
+              type: number
+              format: double
+    ImagemapMessage:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#imagemap-message
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            baseUrl:
+              type: string
+              format: uri
+            altText:
+              type: string
+            baseSize:
+              "$ref": "#/components/schemas/ImagemapBaseSize"
+            actions:
+              type: array
+              items:
+                "$ref": "#/components/schemas/ImagemapAction"
+            video:
+              "$ref": "#/components/schemas/ImagemapVideo"
+    ImagemapBaseSize:
+      type: object
+      properties:
+        height:
+          type: integer
+          format: int32
+        width:
+          type: integer
+          format: int32
+    ImagemapAction:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#imagemap-action-objects
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        area:
+          "$ref": "#/components/schemas/ImagemapArea"
+      discriminator:
+        propertyName: type
+        mapping:
+          message: "#/components/schemas/MessageImagemapAction"
+          uri: "#/components/schemas/URIImagemapAction"
+    MessageImagemapAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/ImagemapAction"
+        - type: object
+          properties:
+            text:
+              type: string
+            label:
+              type: string
+    URIImagemapAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/ImagemapAction"
+        - type: object
+          properties:
+            linkUri:
+              type: string
+            label:
+              type: string
+    ImagemapArea:
+      type: object
+      properties:
+        x:
+          type: integer
+          format: int32
+        y:
+          type: integer
+          format: int32
+        width:
+          type: integer
+          format: int32
+        height:
+          type: integer
+          format: int32
+    ImagemapVideo:
+      type: object
+      properties:
+        originalContentUrl:
+          type: string
+          format: uri
+        previewImageUrl:
+          type: string
+          format: uri
+        area:
+          "$ref": "#/components/schemas/ImagemapArea"
+        externalLink:
+          "$ref": "#/components/schemas/ImagemapExternalLink"
+    ImagemapExternalLink:
+      type: object
+      properties:
+        linkUri:
+          type: string
+          format: uri
+        label:
+          type: string
+    TemplateMessage:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            altText:
+              type: string
+            template:
+              "$ref": "#/components/schemas/Template"
+    Template:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          buttons: "#/components/schemas/ButtonsTemplate"
+          confirm: "#/components/schemas/ConfirmTemplate"
+          carousel: "#/components/schemas/CarouselTemplate"
+          image_carousel: "#/components/schemas/ImageCarouselTemplate"
+    ButtonsTemplate:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Template"
+        - type: object
+          properties:
+            thumbnailImageUrl:
+              type: string
+              format: uri
+            imageAspectRatio:
+              type: string
+            imageSize:
+              type: string
+            imageBackgroundColor:
+              type: string
+            title:
+              type: string
+            text:
+              type: string
+            defaultAction:
+              "$ref": "#/components/schemas/Action"
+            actions:
+              type: array
+              items:
+                "$ref": "#/components/schemas/Action"
+    ConfirmTemplate:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Template"
+        - type: object
+          properties:
+            text:
+              type: string
+            actions:
+              type: array
+              items:
+                "$ref": "#/components/schemas/Action"
+    CarouselTemplate:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Template"
+        - type: object
+          properties:
+            columns:
+              type: array
+              items:
+                "$ref": "#/components/schemas/CarouselColumn"
+            imageAspectRatio:
+              type: string
+            imageSize:
+              type: string
+    CarouselColumn:
+      description: "Column object for carousel template."
+      type: object
+      properties:
+        thumbnailImageUrl:
+          type: string
+          format: uri
+        imageBackgroundColor:
+          type: string
+        title:
+          type: string
+        text:
+          type: string
+        defaultAction:
+          "$ref": "#/components/schemas/Action"
+        actions:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Action"
+    ImageCarouselTemplate:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Template"
+        - type: object
+          properties:
+            columns:
+              type: array
+              items:
+                "$ref": "#/components/schemas/ImageCarouselColumn"
+    ImageCarouselColumn:
+      type: object
+      properties:
+        imageUrl:
+          type: string
+          format: uri
+        action:
+          "$ref": "#/components/schemas/Action"
+    FlexMessage:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#flex-message
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Message"
+        - type: object
+          properties:
+            altText:
+              type: string
+            contents:
+              "$ref": "#/components/schemas/FlexContainer"
+    FlexContainer:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          bubble: "#/components/schemas/FlexBubble"
+          carousel: "#/components/schemas/FlexCarousel"
+    FlexBubble:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexContainer"
+        - type: object
+          properties:
+            direction:
+              type: string
+              enum:
+                - ltr
+                - rtl
+            styles:
+              "$ref": "#/components/schemas/FlexBubbleStyles"
+            header:
+              "$ref": "#/components/schemas/FlexBox"
+            hero:
+              "$ref": "#/components/schemas/FlexComponent"
+            body:
+              "$ref": "#/components/schemas/FlexBox"
+            footer:
+              "$ref": "#/components/schemas/FlexBox"
+            size:
+              type: string
+              enum:
+                - nano
+                - micro
+                - kilo
+                - mega
+                - giga
+            action:
+              "$ref": "#/components/schemas/Action"
+    FlexCarousel:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexContainer"
+        - type: object
+          properties:
+            contents:
+              type: array
+              items:
+                "$ref": "#/components/schemas/FlexBubble"
+    FlexBubbleStyles:
+      type: object
+      properties:
+        header:
+          "$ref": "#/components/schemas/FlexBlockStyle"
+        hero:
+          "$ref": "#/components/schemas/FlexBlockStyle"
+        body:
+          "$ref": "#/components/schemas/FlexBlockStyle"
+        footer:
+          "$ref": "#/components/schemas/FlexBlockStyle"
+    FlexBlockStyle:
+      type: object
+      properties:
+        backgroundColor:
+          type: string
+        separator:
+          type: boolean
+        separatorColor:
+          type: string
+    FlexComponent:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          box: "#/components/schemas/FlexBox"
+          button: "#/components/schemas/FlexButton"
+          image: "#/components/schemas/FlexImage"
+          video: "#/components/schemas/FlexVideo"
+          icon: "#/components/schemas/FlexIcon"
+          text: "#/components/schemas/FlexText"
+          span: "#/components/schemas/FlexSpan"
+          separator: "#/components/schemas/FlexSeparator"
+          filler: "#/components/schemas/FlexFiller"
+    FlexBox:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - properties:
+            layout:
+              type: string
+              enum:
+                - horizontal
+                - vertical
+                - baseline
+            flex:
+              type: integer
+              format: int32
+            contents:
+              type: array
+              items:
+                "$ref": "#/components/schemas/FlexComponent"
+            spacing:
+              type: string
+            margin:
+              type: string
+            position:
+              type: string
+              enum:
+                - relative
+                - absolute
+            offsetTop:
+              type: string
+            offsetBottom:
+              type: string
+            offsetStart:
+              type: string
+            offsetEnd:
+              type: string
+            backgroundColor:
+              type: string
+            borderColor:
+              type: string
+            borderWidth:
+              type: string
+            cornerRadius:
+              type: string
+            width:
+              type: string
+            maxWidth:
+              type: string
+            height:
+              type: string
+            maxHeight:
+              type: string
+            paddingAll:
+              type: string
+            paddingTop:
+              type: string
+            paddingBottom:
+              type: string
+            paddingStart:
+              type: string
+            paddingEnd:
+              type: string
+            action:
+              "$ref": "#/components/schemas/Action"
+            justifyContent:
+              type: string
+              enum:
+                - center
+                - flex-start
+                - flex-end
+                - space-between
+                - space-around
+                - space-evenly
+            alignItems:
+              type: string
+              enum:
+                - center
+                - flex-start
+                - flex-end
+            background:
+              "$ref": "#/components/schemas/FlexBoxBackground"
+    FlexButton:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            flex:
+              type: integer
+              format: int32
+            color:
+              type: string
+            style:
+              type: string
+              enum:
+                - primary
+                - secondary
+                - link
+            action:
+              "$ref": "#/components/schemas/Action"
+            gravity:
+              type: string
+              enum:
+                - top
+                - bottom
+                - center
+            margin:
+              type: string
+            position:
+              type: string
+              enum:
+                - relative
+                - absolute
+            offsetTop:
+              type: string
+            offsetBottom:
+              type: string
+            offsetStart:
+              type: string
+            offsetEnd:
+              type: string
+            height:
+              type: string
+              enum:
+                - md
+                - sm
+            adjustMode:
+              type: string
+              enum:
+                - shrink-to-fit
+    FlexImage:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#f-image
+      type: object
+      required:
+        - type
+        - url
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            url:
+              type: string
+              format: uri
+              description: |+
+                Image URL (Max character limit: 2000)
+                Protocol: HTTPS (TLS 1.2 or later)
+                Image format: JPEG or PNG
+                Maximum image size: 1024×1024 pixels
+                Maximum file size: 10 MB (300 KB when the animated property is true)
+            flex:
+              type: integer
+              format: int32
+              description: "The ratio of the width or height of this component within the parent box."
+            margin:
+              type: string
+              description: |+
+                The minimum amount of space to include before this component in its parent container.
+            position:
+              type: string
+              enum:
+                - relative
+                - absolute
+              description: |+
+                Reference for offsetTop, offsetBottom, offsetStart, and offsetEnd. Specify one of the following values:
 
-            `processing`: Preparing to get content.
-            `succeeded`: Ready to get the content. You can get the content sent by users.
-            `failed`: Failed to prepare to get the content.
-          enum:
-            - processing
-            - succeeded
-            - failed
+                `relative`: Use the previous box as reference.
+                `absolute`: Use the top left of parent element as reference. The default value is relative.
+            offsetTop:
+              type: string
+              description: "Offset."
+            offsetBottom:
+              type: string
+              description: "Offset."
+            offsetStart:
+              type: string
+              description: "Offset."
+            offsetEnd:
+              type: string
+              description: "Offset."
+            align:
+              type: string
+              enum:
+                - start
+                - end
+                - center
+              description: |+
+                Alignment style in horizontal direction.
+            gravity:
+              type: string
+              enum:
+                - top
+                - bottom
+                - center
+              description: "Alignment style in vertical direction."
+            size:
+              type: string
+              default: md
+              description: |+
+                The maximum image width. This is md by default.
+            aspectRatio:
+              type: string
+              description: |+
+                Aspect ratio of the image.
+                `{width}:{height}` format.
+                Specify the value of `{width}` and `{height}` in the range from `1` to `100000`.
+                However, you cannot set `{height}` to a value that is more than three times the value of `{width}`.
+                The default value is `1:1`.
+            aspectMode:
+              type: string
+              enum:
+                - fit
+                - cover
+              description: |+
+                The display style of the image if the aspect ratio of the image and that specified by the aspectRatio property do not match.
+            backgroundColor:
+              type: string
+              description: "Background color of the image. Use a hexadecimal color code."
+            action:
+              "$ref": "#/components/schemas/Action"
+            animated:
+              type: boolean
+              default: false
+              description: |+
+                When this is `true`, an animated image (APNG) plays.
+                You can specify a value of true up to 10 images in a single message.
+                You can't send messages that exceed this limit. 
+                This is `false` by default.
+                Animated images larger than 300 KB aren't played back.
+    FlexVideo:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            previewUrl:
+              type: string
+              format: uri
+            altContent:
+              "$ref": "#/components/schemas/FlexComponent"
+            aspectRatio:
+              type: string
+            action:
+              "$ref": "#/components/schemas/Action"
+    FlexIcon:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#icon
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            size:
+              type: string
+            aspectRatio:
+              type: string
+            margin:
+              type: string
+            position:
+              type: string
+              enum:
+                - relative
+                - absolute
+            offsetTop:
+              type: string
+            offsetBottom:
+              type: string
+            offsetStart:
+              type: string
+            offsetEnd:
+              type: string
+    FlexText:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            flex:
+              type: integer
+              format: int32
+            text:
+              type: string
+            size:
+              type: string
+            align:
+              type: string
+              enum:
+                - start
+                - end
+                - center
+            gravity:
+              type: string
+              enum:
+                - top
+                - bottom
+                - center
+            color:
+              type: string
+            weight:
+              type: string
+              enum:
+                - regular
+                - bold
+            style:
+              type: string
+              enum:
+                - normal
+                - italic
+            decoration:
+              type: string
+              enum:
+                - none
+                - underline
+                - line-through
+            wrap:
+              type: boolean
+            lineSpacing:
+              type: string
+            margin:
+              type: string
+            position:
+              type: string
+              enum:
+                - relative
+                - absolute
+            offsetTop:
+              type: string
+            offsetBottom:
+              type: string
+            offsetStart:
+              type: string
+            offsetEnd:
+              type: string
+            action:
+              "$ref": "#/components/schemas/Action"
+            maxLines:
+              type: integer
+              format: int32
+            contents:
+              type: array
+              items:
+                "$ref": "#/components/schemas/FlexSpan"
+            adjustMode:
+              type: string
+              enum:
+                - shrink-to-fit
+    FlexSpan:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            text:
+              type: string
+            size:
+              type: string
+            color:
+              type: string
+            weight:
+              type: string
+              enum:
+                - regular
+                - bold
+            style:
+              type: string
+              enum:
+                - normal
+                - italic
+            decoration:
+              type: string
+              enum:
+                - none
+                - underline
+                - line-through
+    FlexSeparator:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            margin:
+              type: string
+            color:
+              type: string
+    # TODO: Delete FlexSpacer. It's obsolete.
+    FlexSpacer:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            size:
+              type: string
+              enum:
+                - default
+                - none
+                - xs
+                - sm
+                - md
+                - lg
+                - xl
+                - xxl
+    FlexFiller:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexComponent"
+        - type: object
+          properties:
+            flex:
+              type: integer
+              format: int32
+    FlexBoxBackground:
+      required:
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          linearGradient: "#/components/schemas/FlexBoxLinearGradient"
+    FlexBoxLinearGradient:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/FlexBoxBackground"
+        - type: object
+          properties:
+            angle:
+              type: string
+            startColor:
+              type: string
+            endColor:
+              type: string
+            centerColor:
+              type: string
+            centerPosition:
+              type: string
+
+    # Action objects
+    Action:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#action-objects
+      description: "Action"
+      type: object
+      properties:
+        type:
+          type: string
+          description: "Type of action"
+        label:
+          type: string
+          description: "Label for the action."
+      discriminator:
+        propertyName: type
+        mapping:
+          camera: "#/components/schemas/CameraAction"
+          cameraRoll: "#/components/schemas/CameraRollAction"
+          datetimepicker: "#/components/schemas/DatetimePickerAction"
+          location: "#/components/schemas/LocationAction"
+          message: "#/components/schemas/MessageAction"
+          postback: "#/components/schemas/PostbackAction"
+          richmenuswitch: "#/components/schemas/RichMenuSwitchAction"
+          uri: "#/components/schemas/URIAction"
+    CameraAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+    CameraRollAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+    DatetimePickerAction:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#datetime-picker-action
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+        - type: object
+          properties:
+            data:
+              maxLength: 300
+              minLength: 0
+              type: string
+            mode:
+              type: string
+              enum:
+                - date
+                - time
+                - datetime
+            initial:
+              type: string
+            max:
+              type: string
+            min:
+              type: string
+    LocationAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+    MessageAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+        - type: object
+          properties:
+            text:
+              type: string
+    PostbackAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+        - type: object
+          properties:
+            data:
+              maxLength: 300
+              minLength: 0
+              type: string
+            displayText:
+              type: string
+            text:
+              type: string
+            inputOption:
+              type: string
+              enum:
+                - closeRichMenu
+                - openRichMenu
+                - openKeyboard
+                - openVoice
+            fillInText:
+              type: string
+    RichMenuSwitchAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+        - type: object
+          properties:
+            data:
+              maxLength: 300
+              minLength: 0
+              type: string
+            richMenuAliasId:
+              maxLength: 32
+              minLength: 0
+              type: string
+    URIAction:
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/Action"
+        - type: object
+          properties:
+            uri:
+              type: string
+              format: uri
+            altUri:
+              "$ref": "#/components/schemas/AltUri"
+    AltUri:
+      type: object
+      properties:
+        desktop:
+          maxLength: 1000
+          minLength: 0
+          type: string
+
+    # Error response
+    ErrorResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#error-responses
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: "Message containing information about the error."
+        details:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+          description: "An array of error details. If the array is empty, this property will not be included in the response."
+    ErrorDetail:
+      type: object
+      properties:
+        message:
+          type: string
+          description: "Details of the error. Not included in the response under certain situations."
+        property:
+          type: string
+          description: "Location of where the error occurred. Returns the JSON field name or query parameter name of the request. Not included in the response under certain situations."


### PR DESCRIPTION
This pull request sorts the API order in accordance with the order described in the documentation(https://developers.line.biz/en/reference/messaging-api/).

Related to https://github.com/line/line-openapi/issues/4