### PR TITLE
Delete obsolete definition in FlexMessage

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -1173,7 +1173,6 @@ paths:
         "200":
           description: "OK"
           content:
-            # TODO check the content-type of the actual implementation and replace here.
             "*/*":
               schema:
                 type: string
@@ -3757,7 +3756,7 @@ components:
               description: |+
                 When this is `true`, an animated image (APNG) plays.
                 You can specify a value of true up to 10 images in a single message.
-                You can't send messages that exceed this limit. 
+                You can't send messages that exceed this limit.
                 This is `false` by default.
                 Animated images larger than 300 KB aren't played back.
     FlexVideo:
@@ -3921,24 +3920,6 @@ components:
               type: string
             color:
               type: string
-    # TODO: Delete FlexSpacer. It's obsolete.
-    FlexSpacer:
-      type: object
-      allOf:
-        - "$ref": "#/components/schemas/FlexComponent"
-        - type: object
-          properties:
-            size:
-              type: string
-              enum:
-                - default
-                - none
-                - xs
-                - sm
-                - md
-                - lg
-                - xl
-                - xxl
     FlexFiller:
       type: object
       allOf:


### PR DESCRIPTION
spacer has been deleted from developers document. We should delete this.