### PR TITLE
Rename title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# line-openapi
+# LINE OpenAPI
 
 ## What's this?
 


### PR DESCRIPTION
The Linux Foundation has registered the term "OpenAPI" as a trademark and has provided some guidelines for its use. Therefore, we need to change the title.