### PR TITLE
Flex Message Update 4

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3511,6 +3511,8 @@ components:
               enum:
                 - nano
                 - micro
+                - deca
+                - hecto
                 - kilo
                 - mega
                 - giga
@@ -3694,6 +3696,8 @@ components:
               type: string
               enum:
                 - shrink-to-fit
+            scaling:
+              type: boolean
     FlexImage:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#f-image
@@ -3841,6 +3845,8 @@ components:
               type: string
             offsetEnd:
               type: string
+            scaling:
+              type: boolean
     FlexText:
       type: object
       allOf:
@@ -3916,6 +3922,8 @@ components:
               type: string
               enum:
                 - shrink-to-fit
+            scaling:
+              type: boolean
     FlexSpan:
       type: object
       allOf:


### PR DESCRIPTION
news: https://developers.line.biz/en/news/2023/07/04/flex-message-update-4-released/

1. The deca and hecto values in the size property have been added to the [bubble](https://developers.line.biz/en/reference/messaging-api/#bubble).
2. The scaling property is now available on [Button](https://developers.line.biz/en/reference/messaging-api/#button), [Text](https://developers.line.biz/en/reference/messaging-api/#f-text), and [Icon](https://developers.line.biz/en/reference/messaging-api/#icon).