### PR TITLE
Modify example of getAudienceData

### DIFF
--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -331,7 +331,7 @@ paths:
                         description: "audience_list.txt"
                         type: DIFF_ADD
                         status: FINISHED
-                        failedType: ~
+                        failedType: AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT
                         audienceCount: 0
                         created: 1608617472
                         jobStatus: FINISHED


### PR DESCRIPTION
CI reported `setup: manage-audience.yml#L334 oas3-valid-media-example "failedType" property type must be string`. It blocks merging https://github.com/line/line-openapi/pull/26 into main branch.

ref: https://github.com/line/line-openapi/actions/runs/5477144819