### PR TITLE
Channel API doesn't require token as a header

### DIFF
--- a/channel-access-token.yml
+++ b/channel-access-token.yml
@@ -9,9 +9,6 @@ info:
 servers:
   - url: "https://api.line.me"
 
-security:
-  - Bearer: []
-
 tags:
   - name: channel-access-token
 

--- a/channel-access-token.yml
+++ b/channel-access-token.yml
@@ -277,12 +277,6 @@ paths:
           description: "OK"
 
 components:
-  securitySchemes:
-    Bearer:
-      type: http
-      scheme: bearer
-      description: "Channel access token"
-
   schemas:
     IssueStatelessChannelTokenByJWTAssertionRequest:
       externalDocs:


### PR DESCRIPTION
(To check generated code)