### PR TITLE
Include newly added and deleted files in diff display

### DIFF
--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -72,7 +72,9 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Update version in linebot/__about__.py
         run: |
@@ -143,7 +145,9 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Run unit tests
         run: ./vendor/bin/phpunit --test-suffix=Test.php
@@ -185,7 +189,9 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Test Project
         run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
@@ -230,9 +236,11 @@ jobs:
   
       - name: Generate code
         run: python generate-code.py
-  
+
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: run tests
         run: go test ./...


### PR DESCRIPTION
`Show diff` in CI is very useful to check what happens in each SDK. I found this didn't show new and deleted files, and it only shows changed files. This change allow us to see new and deleted files in CI.

This change is tested in https://github.com/line/line-openapi/actions/runs/7059652012/job/19217647056?pr=43