### PR TITLE
Add patch version in liff.yml

### DIFF
--- a/liff.yml
+++ b/liff.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 info:
   title: LIFF server API
-  version: "1.0"
+  version: "1.0.0"
   description: "LIFF Server API."
 
 servers:


### PR DESCRIPTION
# Overview

Add `patch version` to liff.yaml (info.version)

## Details

I am currently developing a `line-bot-sdk` for Rust.
When I auto-generate code with `openapi-generator-cli`, I noticed that the version notation in the riff does not include the `patch version`.

![image](https://github.com/line/line-openapi/assets/49806926/8d1b336c-70bc-417e-88b6-78f4964f74bf)

Other modules (`channel-access-token`, `insight`, `manage-audience`, `messaging-api`, `module-attach`, `module`, `shop`, `webhook`) have `patch version` but only `liff` was not written.

OpenAPI should be used in a variety of languages.

I know this is a small matter, but I hope it will be approved.