### PR TITLE
Define keywords for flex components

### DIFF
--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -34,7 +34,9 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Execute Java SDK test
         run: ./gradlew build
@@ -72,7 +74,9 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Update version in linebot/__about__.py
         run: |
@@ -143,7 +147,9 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Run unit tests
         run: ./vendor/bin/phpunit --test-suffix=Test.php
@@ -185,7 +191,9 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: git diff --color=always
+        run: |
+          git add .
+          git diff --color=always --staged
 
       - name: Test Project
         run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
@@ -232,8 +240,9 @@ jobs:
         run: python generate-code.py
   
       - name: Show diff
-        run: git diff --color=always
-
+        run: |
+          git add .
+          git diff --color=always --staged
       - name: run tests
         run: go test ./...
   

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -34,9 +34,7 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: |
-          git add .
-          git diff --color=always --staged
+        run: git diff --color=always
 
       - name: Execute Java SDK test
         run: ./gradlew build
@@ -74,9 +72,7 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: |
-          git add .
-          git diff --color=always --staged
+        run: git diff --color=always
 
       - name: Update version in linebot/__about__.py
         run: |
@@ -147,9 +143,7 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Show diff
-        run: |
-          git add .
-          git diff --color=always --staged
+        run: git diff --color=always
 
       - name: Run unit tests
         run: ./vendor/bin/phpunit --test-suffix=Test.php
@@ -191,9 +185,7 @@ jobs:
         run: python3 generate-code.py
 
       - name: Show diff
-        run: |
-          git add .
-          git diff --color=always --staged
+        run: git diff --color=always
 
       - name: Test Project
         run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
@@ -240,9 +232,8 @@ jobs:
         run: python generate-code.py
   
       - name: Show diff
-        run: |
-          git add .
-          git diff --color=always --staged
+        run: git diff --color=always
+
       - name: run tests
         run: go test ./...
   

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3705,6 +3705,28 @@ components:
               type: array
               items:
                 "$ref": "#/components/schemas/Action"
+    TemplateImageAspectRatio:
+      type: string
+      description: |+
+        Aspect ratio of the image. This is only for the `imageAspectRatio` in ButtonsTemplate.
+        Specify one of the following values:
+        
+        `rectangle`: 1.51:1
+        `square`: 1:1
+      enum:
+        - rectangle
+        - square
+    TemplateImageSize:
+      type: string
+      description: |+
+        Size of the image.  This is only for the `imageSize` in ButtonsTemplate.
+        Specify one of the following values:
+        
+        `cover`: The image fills the entire image area. Parts of the image that do not fit in the area are not displayed.
+        `contain`: The entire image is displayed in the image area. A background is displayed in the unused areas to the left and right of vertical images and in the areas above and below horizontal images.
+      enum:
+        - cover
+        - contain
     ConfirmTemplate:
       type: object
       required:
@@ -3975,6 +3997,151 @@ components:
                 - flex-end
             background:
               "$ref": "#/components/schemas/FlexBoxBackground"
+    FlexBoxBorderWidth:
+      type: string
+      description: |+
+        Width of box border. This is only for `borderWidth` in FlexBox.
+        A value of none means that borders are not rendered; the other values are listed in order of increasing width.
+      enum:
+        - none
+        - light
+        - normal
+        - medium
+        - semi-bold
+        - bold
+    FlexBoxCornerRadius:
+      type: string
+      description: |+
+        Radius at the time of rounding the corners of the box. This is only for `cornerRadius` in FlexBox.
+        A value of none means that corners are not rounded; the other values are listed in order of increasing radius.
+      enum:
+        - none
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+    FlexBoxSpacing:
+      type: string
+      description: |+
+        You can specify the minimum space between two components with the `spacing` property of the parent box component, in pixels or with a keyword. 
+        FlexBoxSpacing just provides only keywords.
+      enum:
+        - none
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+    FlexMargin:
+      type: string
+      description: |+
+        You can specify the minimum space before a child component with the `margin` property of the child component, in pixels or with a keyword. 
+        FlexMargin just provides only keywords.
+      enum:
+        - none
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+    FlexBoxPadding:
+      type: string
+      description: |+
+        Padding can be specified in pixels, percentage (to the parent box width) or with a keyword.
+        FlexBoxPadding just provides only keywords.
+      enum:
+        - none
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+    FlexImageSize:
+      type: string
+      description: |+
+        You can set the width of an Flex image component with the `size` property, in pixels, as a percentage, or with a keyword.
+        FlexImageSize just provides only keywords.
+      enum:
+        - xxs
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+        - 3xl
+        - 4xl
+        - 5xl
+        - full
+    FlexIconSize:
+      type: string
+      description: |+
+        You can set the width of an Flex icon component with the `size` property, in pixels, as a percentage, or with a keyword.
+        FlexIconSize just provides only keywords.
+      enum:
+        - xxs
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+        - 3xl
+        - 4xl
+        - 5xl
+    FlexTextFontSize:
+      type: string
+      description: |+
+        Font size in the `size` property of the Flex text component.
+        You can specify the size in pixels or with a keyword. 
+        FlexTextFontSize just provides only keywords.
+      enum:
+        - xxs
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+        - 3xl
+        - 4xl
+        - 5xl
+    FlexSpanSize:
+      type: string
+      description: |+
+        Font size in the `size` property of the Flex span component.
+        You can specify the size in pixels or with a keyword. 
+        FlexSpanSize just provides only keywords.
+      enum:
+        - xxs
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
+        - 3xl
+        - 4xl
+        - 5xl
+    FlexOffset:
+      type: string
+      description: |+
+        You can specify the offset of a component with the `offset*` property, in pixels or with a keyword.
+        You can also specify the percentage to the box width for `offsetStart` and `offsetEnd` and to the box height for `offsetTop` and `offsetBottom`.
+        FlexOffset just provides only keywords.
+      enum:
+        - none
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+        - xxl
     FlexButton:
       type: object
       required:


### PR DESCRIPTION
This pull request defines the keywords that can be specified for template messages and flex messages as enums. In addition to keywords, template messages and flex messages can specify values in percentages or pixels. 
(e.g. image size in flex message: https://developers.line.biz/en/docs/messaging-api/flex-message-layout/#image-size)

Therefore, we will not define the new enum as a value that can be specified for template messages and flex messages.

The main purpose of this change is to provide support for users who use the bot SDK to have the option to use enums.

Resolve https://github.com/line/line-openapi/issues/42