### PR TITLE
Add isUnblocked flag to Follow Webhook event.

### DIFF
--- a/webhook.yml
+++ b/webhook.yml
@@ -529,10 +529,21 @@ components:
         - type: object
           required:
             - replyToken
+            - follow
           properties:
             replyToken:
               type: string
               description: "Reply token used to send reply message to this event"
+            follow:
+              "$ref": "#/components/schemas/FollowDetail"
+    FollowDetail:
+      type: object
+      required:
+        - isUnblocked
+      properties:
+        isUnblocked:
+          type: boolean
+          description: "Whether a user has added your LINE Official Account as a friend or unblocked."
 
 
     # https://developers.line.biz/en/reference/messaging-api/#unfollow-event


### PR DESCRIPTION
In the Messaging API, you can now determine whether a user has added your LINE Official Account as a friend or unblocked by a webhook follow event.

News: https://developers.line.biz/en/news/2024/02/06/add-friends-and-unblock-friends-can-now-be-determined-by-webhook/