### PR TITLE
Add membership api doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you have an interesting use case for these files or have a request, please cr
 | module.yml               | 3.0.0           | https://api.line.me/v2/bot/                                                               | Messaging API            |
 | module-attach.yml        | 3.0.0           | https://manager.line.biz/module/auth/v1/token                                             | Messaging API            |
 | shop.yml                 | 3.0.0           | https://api.line.me/shop/                                                                 | Mission Stickers API     |
+| membership.yml           | 3.0.0           | https://api.line.me/membership                                                            | Membership API            |
 |                          |                 |                                                                                           |                          |
 | webhook.yml              | 3.0.3           |                                                                                           | Webhook Event Objects    |
 

--- a/membership.yml
+++ b/membership.yml
@@ -1,0 +1,301 @@
+---
+openapi: 3.0.0
+info:
+  title: Membership API
+  version: "0.0.1"
+  description:
+    This document describes LINE Official Account Membership API.
+
+servers:
+  - url: "https://api.line.me"
+
+security:
+  - Bearer: []
+
+tags:
+  - name: membership
+
+paths:
+  "/membership/v1/subscription/{userId}":
+    get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-a-users-membership-subscription-status
+      tags:
+        - membership
+      operationId: getMembershipSubscription
+      description: "Get a user's membership subscription."
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "User ID"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetMembershipSubscriptionResponse"
+              example:
+                subscriptions:
+                  - membership:
+                      membershipId: 3189
+                      title: "Basic Plan"
+                      description: "You will receive messages and photos every Saturday."
+                      benefits: 
+                        - "Members Only Messages"
+                        - "Members Only Photos"
+                      price: 500.00
+                      currency: "JPY"
+                    user:
+                      membershipNo: 1
+                      joinedTime: 1707214784
+                      nextBillingDate: "2024-02-08"
+                      totalSubscriptionMonths: 1
+
+        "400":
+          description: "An invalid user ID is specified."
+          content:
+            application/json:
+              schema:
+                  "$ref": "#/components/schemas/MembershipListResponse"
+        "404":
+          description: "Unable to get information about the membership to which the user subscribes."
+          content:
+            application/json:
+              schema:
+                  "$ref": "#/components/schemas/MembershipListResponse"
+  "/membership/v1/list":
+    get:
+      tags:
+        - membership
+      operationId: getMembershipList
+      description: "Get a list of memberships."
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MembershipListResponse"
+              example:
+                memberships:
+                  - membershipId: 3189
+                    title: "Basic Plan"
+                    description: "You will receive messages and photos every Saturday."
+                    benefits: 
+                      - "Members Only Messages"
+                      - "Members Only Photos"
+                    price: 500.00
+                    currency: "JPY"
+                    memberCount: 1
+                    memberLimit: null
+                    isInAppPurchase: true
+                    isPublished: true
+                  - membershipId: 3213
+                    title: "Premium Plan"
+                    description: "Invitation to a special party."
+                    benefits: 
+                      - "Members Only Party"
+                    price: 1500.00
+                    currency: "JPY"
+                    memberCount: 0
+                    memberLimit: null
+                    isInAppPurchase: false
+                    isPublished: true
+        "404":
+          description: "Unable to get information about the memberships."
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+
+components:
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+      description: "Channel access token"
+
+  schemas:
+    GetMembershipSubscriptionResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-a-users-membership-subscription-status
+      description: "A user's membership subscription status"
+      required:
+        - subscriptions
+      type: object
+      properties:
+        subscriptions:
+          type: array
+          maxItems: 5
+          minItems: 0
+          description: "List of subscription information"
+          items:
+            "$ref": "#/components/schemas/Subscription"
+
+    MembershipListResponse:
+      description: "List of memberships"
+      required:
+        - memberships
+      type: object
+      properties:
+        memberships:
+          type: array
+          maxItems: 5
+          minItems: 0
+          description: "List of membership information"
+          items:
+            "$ref": "#/components/schemas/Membership"
+
+    Subscription:
+      description: "An array of memberships."
+      required:
+        - membership
+        - user
+      type: object
+      properties:
+        membership:
+          "$ref": "#/components/schemas/MembershipMeta"
+        user:
+          "$ref": "#/components/schemas/MembershipUser"
+
+    MembershipMeta:
+      description: "Object containing information about the membership plan."
+      type: object
+      required:
+        - membershipId
+        - title
+        - description
+        - benefits
+        - price
+        - currency
+      properties:
+        membershipId:
+          type: integer
+          description: "Membership plan ID."
+        title:
+          type: string
+          description: "Membership plan name."
+        description:
+          type: string
+          description: "Membership plan description."
+        benefits:
+          type: array
+          minItems: 1
+          maxItems: 5
+          items:
+            type: string
+          description: "List of membership plan perks."
+        price:
+          type: number
+          format: double
+          example: 500.00
+          description: "Monthly fee for membership plan. (e.g. 1500.00)"
+        currency:
+          type: string
+          description: "The currency of membership.price."
+          enum:
+            - JPY
+            - TWD
+            - THB
+            - IDR
+
+    MembershipUser:
+      description: "Object containing user membership subscription information."
+      type: object
+      required:
+        - membershipNo
+        - joinedTime
+        - nextBillingDate
+        - totalSubscriptionMonths
+      properties:
+        membershipNo:
+          type: integer
+          description: "The user's member number in the membership plan."
+        joinedTime:
+          type: integer
+          description: "UNIX timestamp at which the user subscribed to the membership."
+        nextBillingDate:
+          type: string
+          description: |
+            Next payment date for membership plan.
+            - Format: yyyy-MM-dd (e.g. 2024-02-08)
+            - Timezone: UTC+9
+        totalSubscriptionMonths:
+          type: integer
+          description: "The period of time in months that the user has been subscribed to a membership plan. If a user previously canceled and then re-subscribed to the same membership plan, only the period after the re-subscription will be counted."
+    
+
+    Membership:
+      required:
+        - membershipId
+        - title
+        - description
+        - benefits
+        - price
+        - currency
+        - memberCount
+        - memberLimit
+        - isInAppPurchase
+        - isPublished
+      type: object
+      properties:
+        membershipId:
+          type: integer
+          description: "Membership plan ID."
+        title:
+          type: string
+          description: "Membership plan name."
+        description:
+          type: string
+          description: "Membership plan description."
+        benefits:
+          type: array
+          minItems: 1
+          maxItems: 5
+          items:
+            type: string
+          description: "List of membership plan perks."
+        price:
+          type: number
+          format: double
+          example: 500.00
+          description: "Monthly fee for membership plan. (e.g. 1500.00)"
+        currency:
+          type: string
+          description: "The currency of membership.price."
+          enum:
+            - JPY
+            - TWD
+            - THB
+            - IDR
+        memberCount:
+          type: integer
+          example: 100
+          description: "Number of members subscribed to the membership plan."
+        memberLimit:
+          type: integer
+          nullable: true
+          example: 1000
+          description: "The upper limit of members who can subscribe. If no upper limit is set, it will be null."
+        isInAppPurchase:
+          type: boolean
+          description: "Payment method for users who subscribe to a membership plan."
+        isPublished:
+          type: boolean
+          description: "Membership plan status."
+    ErrorResponse:
+      required:
+        - message
+      type: object
+      properties:
+        message:
+          type: string
+          description: "Error message"
+        details:
+          type: array
+          items:
+            type: string

--- a/membership.yml
+++ b/membership.yml
@@ -68,6 +68,8 @@ paths:
                 "$ref": "#/components/schemas/ErrorResponse"
   "/membership/v1/list":
     get:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#get-membership-plans
       tags:
         - membership
       operationId: getMembershipList

--- a/membership.yml
+++ b/membership.yml
@@ -59,13 +59,13 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/MembershipListResponse"
+                "$ref": "#/components/schemas/ErrorResponse"
         "404":
           description: "Unable to get information about the membership to which the user subscribes."
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/MembershipListResponse"
+                "$ref": "#/components/schemas/ErrorResponse"
   "/membership/v1/list":
     get:
       tags:

--- a/membership.yml
+++ b/membership.yml
@@ -186,7 +186,6 @@ components:
         benefits:
           type: array
           minItems: 1
-          maxItems: 5
           items:
             type: string
           description: "List of membership plan perks."

--- a/membership.yml
+++ b/membership.yml
@@ -3,8 +3,7 @@ openapi: 3.0.0
 info:
   title: Membership API
   version: "0.0.1"
-  description:
-    This document describes LINE Official Account Membership API.
+  description: This document describes LINE Official Account Membership API.
 
 servers:
   - url: "https://api.line.me"
@@ -44,7 +43,7 @@ paths:
                       membershipId: 3189
                       title: "Basic Plan"
                       description: "You will receive messages and photos every Saturday."
-                      benefits: 
+                      benefits:
                         - "Members Only Messages"
                         - "Members Only Photos"
                       price: 500.00
@@ -60,13 +59,13 @@ paths:
           content:
             application/json:
               schema:
-                  "$ref": "#/components/schemas/MembershipListResponse"
+                "$ref": "#/components/schemas/MembershipListResponse"
         "404":
           description: "Unable to get information about the membership to which the user subscribes."
           content:
             application/json:
               schema:
-                  "$ref": "#/components/schemas/MembershipListResponse"
+                "$ref": "#/components/schemas/MembershipListResponse"
   "/membership/v1/list":
     get:
       tags:
@@ -85,7 +84,7 @@ paths:
                   - membershipId: 3189
                     title: "Basic Plan"
                     description: "You will receive messages and photos every Saturday."
-                    benefits: 
+                    benefits:
                       - "Members Only Messages"
                       - "Members Only Photos"
                     price: 500.00
@@ -97,7 +96,7 @@ paths:
                   - membershipId: 3213
                     title: "Premium Plan"
                     description: "Invitation to a special party."
-                    benefits: 
+                    benefits:
                       - "Members Only Party"
                     price: 1500.00
                     currency: "JPY"
@@ -227,7 +226,6 @@ components:
         totalSubscriptionMonths:
           type: integer
           description: "The period of time in months that the user has been subscribed to a membership plan. If a user previously canceled and then re-subscribed to the same membership plan, only the period after the re-subscription will be counted."
-    
 
     Membership:
       required:

--- a/membership.yml
+++ b/membership.yml
@@ -254,7 +254,6 @@ components:
         benefits:
           type: array
           minItems: 1
-          maxItems: 5
           items:
             type: string
           description: "List of membership plan perks."

--- a/membership.yml
+++ b/membership.yml
@@ -202,7 +202,6 @@ components:
             - JPY
             - TWD
             - THB
-            - IDR
 
     MembershipUser:
       description: "Object containing user membership subscription information."
@@ -271,7 +270,6 @@ components:
             - JPY
             - TWD
             - THB
-            - IDR
         memberCount:
           type: integer
           example: 100

--- a/membership.yml
+++ b/membership.yml
@@ -131,7 +131,6 @@ components:
       properties:
         subscriptions:
           type: array
-          maxItems: 5
           minItems: 0
           description: "List of subscription information"
           items:
@@ -145,7 +144,6 @@ components:
       properties:
         memberships:
           type: array
-          maxItems: 5
           minItems: 0
           description: "List of membership information"
           items:


### PR DESCRIPTION
In the Messaging API, you can now get membership information.
- add `/membership/v1/subscription/{userId}`
- add `/membership/v1/list`

News: https://developers.line.biz/en/news/2024/02/09/get-membership-plan-informations/
