### PR TITLE
Loading animation

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -1925,6 +1925,33 @@ paths:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
 
+  "/v2/bot/chat/loading/start":
+    post:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
+      tags:
+        - messaging-api
+      operationId: showLoadingAnimation
+      description: "Display a loading animation in one-on-one chats between users and LINE Official Accounts."
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ShowLoadingAnimationRequest"
+        required: true
+      responses:
+        "202":
+          description: "Accepted"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/ShowLoadingAnimationResponse"
+        "400":
+          description: "An invalid chat ID is specified, or the loadingSeconds value is invalid."
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
 
 components:
   securitySchemes:
@@ -4925,6 +4952,29 @@ components:
         isPublished:
           type: boolean
           description: "Membership plan status."
+
+    ShowLoadingAnimationRequest:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
+      required:
+        - chatId
+      type: object
+      properties:
+        chatId:
+          type: string
+          description: "User ID of the target user for whom the loading animation is to be displayed."
+        loadingSeconds:
+          type: integer
+          format: int32
+          maximum: 60
+          minimum: 5
+          description: |+
+            The number of seconds to display the loading indicator.
+            It must be a multiple of 5. The maximum value is 60 seconds.
+    ShowLoadingAnimationResponse:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator-response
+      type: object
 
     # Error response
     ErrorResponse:

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -4955,7 +4955,7 @@ components:
 
     ShowLoadingAnimationRequest:
       externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
+        url: https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator-request-body
       required:
         - chatId
       type: object


### PR DESCRIPTION
In the Messaging API, we've added a new endpoint that allows you to [display a loading animation](https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator). After your LINE Official Account receives a message from a user, the response may takes some time due to message preparation or reservation processing. In such cases, you can visually tell the user that you want them to wait by displaying a loading animation.

news: https://developers.line.biz/en/news/2024/04/17/loading-indicator/

![loading-animation 7aad3d6c](https://github.com/line/line-openapi/assets/24933664/4435a2c1-db0c-409a-92f1-7c5fb64903c3)


