### PR TITLE
add required options on module-attach

### DIFF
--- a/module-attach.yml
+++ b/module-attach.yml
@@ -68,6 +68,10 @@ paths:
                 brand_type:
                   type: string
                   description: "If you specified a value for brand_type in the URL for authentication and authorization, specify the same value."
+              required:
+                - grant_type
+                - code
+                - redirect_uri
       responses:
         "200":
           content:


### PR DESCRIPTION
## API docs
- https://developers.line.biz/en/reference/partner-docs/#link-attach-by-operation-module-channel-provider
<img width="888" alt="スクリーンショット 2024-04-21 12 54 10" src="https://github.com/line/line-openapi/assets/8898432/9880ea75-c45b-485e-b78f-4b205e38e4e1">

### before
<img width="1428" alt="スクリーンショット 2024-04-21 12 56 08" src="https://github.com/line/line-openapi/assets/8898432/7fae08d5-2817-4531-9ad1-51af8ab45c21">

### after
<img width="1429" alt="スクリーンショット 2024-04-21 12 55 01" src="https://github.com/line/line-openapi/assets/8898432/a5345987-f07e-4888-a561-4ebcb06feb35">
