### PR TITLE
Use env to get branch name and url

### DIFF
--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -19,9 +19,12 @@ jobs:
       - name: Update line-openapi submodule
         run: |
           cd line-openapi
-          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
-          git fetch pr-source ${{ github.event.pull_request.head.ref }}
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
           git checkout FETCH_HEAD
+        env:
+          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
 
       # https://github.com/line/line-bot-sdk-java/blob/master/.github/workflows/gradle.yml
       - name: Setup Java
@@ -54,9 +57,12 @@ jobs:
       - name: Update line-openapi submodule
         run: |
           cd line-openapi
-          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
-          git fetch pr-source ${{ github.event.pull_request.head.ref }}
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
           git checkout FETCH_HEAD
+        env:
+          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
 
       # https://github.com/line/line-bot-sdk-python/blob/master/.github/workflows/auto-testing.yml
       - name: Setup Python
@@ -98,9 +104,12 @@ jobs:
       - name: Update line-openapi submodule
         run: |
           cd line-openapi
-          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
-          git fetch pr-source ${{ github.event.pull_request.head.ref }}
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
           git checkout FETCH_HEAD
+        env:
+          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
 
       # https://github.com/line/line-bot-sdk-php/blob/master/.github/workflows/php-checks.yml
       - name: Setup PHP
@@ -167,9 +176,12 @@ jobs:
       - name: Update line-openapi submodule
         run: |
           cd line-openapi
-          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
-          git fetch pr-source ${{ github.event.pull_request.head.ref }}
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
           git checkout FETCH_HEAD
+        env:
+          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
 
       # https://github.com/line/line-bot-sdk-nodejs/blob/master/.github/workflows/test.yml
       - name: actions/setup-java@v3
@@ -211,9 +223,12 @@ jobs:
       - name: Update line-openapi submodule
         run: |
           cd line-openapi
-          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
-          git fetch pr-source ${{ github.event.pull_request.head.ref }}
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
           git checkout FETCH_HEAD
+        env:
+          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
 
       # https://github.com/line/line-bot-sdk-go/blob/master/.github/workflows/go.yml
       - name: actions/setup-java@v3


### PR DESCRIPTION
```
          git remote add pr-source ${{ github.event.pull_request.head.repo.clone_url }}
          git fetch pr-source ${{ github.event.pull_request.head.ref }}
```
allow attacker to run any command, although currently this repository doesn't expose secrets(it doesn't mean github workflow's secret)

See https://securitylab.github.com/advisories/GHSL-2023-110_Wing_Language/