### PR TITLE
Make Limit.max nullable

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -2665,6 +2665,7 @@ components:
         max:
           minimum: 1
           type: integer
+          nullable: true
           format: int32
           description: |+
             The maximum number of narrowcast messages to send.


### PR DESCRIPTION
### Overview:
The issue reported in [line/line-bot-sdk-go#466](https://github.com/line/line-bot-sdk-go/issues/466) indicates that the `max` field of the `Limit` object specified in a Narrowcast Request does not become null when JSON serialized.

This field accepts values of 1 or more, or null as input. [Reference](https://developers.line.biz/ja/reference/messaging-api/#send-narrowcast-limit)

Therefore, in languages like Golang that do not allow null for primitive types, treating 0 as null in JSON is acceptable.

### Approach:
Modify the OpenAPI definition to make the field nullable, then regenerate the code to add the `omitempty` tag to the `Limit.max` field in `line-bot-sdk-go`.