### PR TITLE
Support new age groups in narrowcast

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -2308,6 +2308,10 @@ components:
         - age_40
         - age_45
         - age_50
+        - age_55
+        - age_60
+        - age_65
+        - age_70
     AppTypeDemographicFilter:
       type: object
       allOf:


### PR DESCRIPTION
In the Messaging API, we've added the following values as conditions for filtering the age range of recipients in the [demographic filter objects](https://developers.line.biz/en/reference/messaging-api/#narrowcast-demographic-filter) of [narrowcast messages](https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message):

- `age_55`
- `age_60`
- `age_65`
- `age_70`

Until now, the upper limit was `age_50`, so it wasn't possible to filter ages over 50 in detail. By specifying the added age ranges, you can now filter recipients more flexibly than before.

For example, the following is a demographic filter object that filters by age 50 and older but less than 60:

```json
{
  "type": "age",
  "gte": "age_50",
  "lt": "age_60"
}
```

news: https://developers.line.biz/en/news/2024/08/26/age-filter-subdivision/