### PR TITLE
Fix CI issues related to zx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-#    - run: npm install -g zx
     - run: npm install -g @stoplight/spectral-cli
     - run: npm install .
-    - run: zx ./tools/validate-all.mjs
-    - run: zx ./tools/validate-request-suffix.mjs
-    - run: zx ./tools/validate-inheritance.mjs
+    - run: npx zx ./tools/validate-all.mjs
+    - run: npx zx ./tools/validate-request-suffix.mjs
+    - run: npx zx ./tools/validate-inheritance.mjs
 
   generate-test:
     runs-on: ubuntu-latest
@@ -32,7 +31,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-#    - run: npm install -g zx
     - run: npm install -g @openapitools/openapi-generator-cli
     - run: openapi-generator-cli version-manager set 7.0.1
     - run: sed -i -e 's/openapi-generator/openapi-generator-cli/g' ./tools/generate-test.mjs
@@ -42,4 +40,4 @@ jobs:
         distribution: 'temurin'
         java-version: 17
         architecture: x64
-    - run: zx ./tools/generate-test.mjs
+    - run: npx zx ./tools/generate-test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-    - run: npm install -g zx
+#    - run: npm install -g zx
     - run: npm install -g @stoplight/spectral-cli
     - run: npm install .
     - run: zx ./tools/validate-all.mjs
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-    - run: npm install -g zx
+#    - run: npm install -g zx
     - run: npm install -g @openapitools/openapi-generator-cli
     - run: openapi-generator-cli version-manager set 7.0.1
     - run: sed -i -e 's/openapi-generator/openapi-generator-cli/g' ./tools/generate-test.mjs


### PR DESCRIPTION
This change resolves https://github.com/line/line-openapi/issues/66.
```
npm install -g zx
```
failed due to permission issue
(log)
```
Run npm install -g zx
npm error code EACCES
npm error syscall symlink
npm error path ../../../lib/node_modules/zx/man/zx.1
npm error dest /usr/local/share/man/man1/zx.1
npm error errno -13
npm error [Error: EACCES: permission denied, symlink '../../../lib/node_modules/zx/man/zx.1' -> '/usr/local/share/man/man1/zx.1'] {
npm error   errno: -13,
npm error   code: 'EACCES',
npm error   syscall: 'symlink',
npm error   path: '../../../lib/node_modules/zx/man/zx.1',
npm error   dest: '/usr/local/share/man/man1/zx.1'
npm error }
npm error
npm error The operation was rejected by your operating system.
npm error It is likely you do not have the permissions to access this file as the current user
npm error
npm error If you believe this might be a permissions issue, please double-check the
npm error permissions of the file and its containing directories, or try running
npm error the command again as root/Administrator.

npm error A complete log of this run can be found in: /home/runner/.npm/_logs/202[4](https://github.com/line/line-openapi/actions/runs/10552186284/job/29230645454?pr=65#step:4:5)-08-26T01_57_10_003Z-debug-0.log
Error: Process completed with exit code 243.
```