### PR TITLE
Support new age groups in insight API

### DIFF
--- a/insight.yml
+++ b/insight.yml
@@ -372,6 +372,11 @@ components:
             - from40to44
             - from45to49
             - from50
+            - from50to54
+            - from55to59
+            - from60to64
+            - from65to69
+            - from70
             - unknown
           description: "users' age"
         percentage:


### PR DESCRIPTION
In the Messaging API, we've added the following values as the percentage of each age group of your LINE Official Account's friends that you can get by using the [Get friend demographics](https://developers.line.biz/en/reference/messaging-api/#get-demographic) endpoint:

- `from50to54`
- `from55to59`
- `from60to64`
- `from65to69`
- `from70`



Previously, we've aggregated the percentage of friends who are 50 and older as a single value, from50. With this change, you can now get statistics on the percentage of friends between the ages of 50 and 70.

We'll continue to include from50 in the response as a value that aggregates the percentage of friends who are 50 and older.

News: https://developers.line.biz/en/news/2024/09/05/age-percentage-subdivision/