### PR TITLE
add UpdateLiffView for liff.yml

### DIFF
--- a/liff.yml
+++ b/liff.yml
@@ -228,6 +228,35 @@ components:
           description: |+
             `true` to use the LIFF app in modular mode.
             When in modular mode, the action button in the header is not displayed.
+    UpdateLiffView:
+      externalDocs:
+        url: https://developers.line.biz/en/reference/liff-server/#update-liff-app
+      type: object
+      properties:
+        type:
+          description: |+
+            Size of the LIFF app view. Specify one of these values:
+            - compact
+            - tall
+            - full
+          type: string
+          enum:
+            - compact
+            - tall
+            - full
+        url:
+          type: string
+          format: uri
+          description: |+
+            Endpoint URL. This is the URL of the web app that implements the LIFF app
+            (e.g. https://example.com).
+            Used when the LIFF app is launched using the LIFF URL.
+            The URL scheme must be https. URL fragments (#URL-fragment) can't be specified.
+        moduleMode:
+          type: boolean
+          description: |+
+            `true` to use the LIFF app in modular mode.
+            When in modular mode, the action button in the header is not displayed.
     LiffFeatures:
       type: object
       properties:
@@ -255,7 +284,7 @@ components:
       type: object
       properties:
         view:
-          $ref: "#/components/schemas/LiffView"
+          $ref: "#/components/schemas/UpdateLiffView"
         description:
           type: string
           description: |+


### PR DESCRIPTION
In `LiffView`, `view.url` and `view.type` are required properties. However, in the LIFF app update API, these properties are not mandatory.
ref: https://developers.line.biz/en/reference/liff-server/#update-liff-app

I have defined a new `UpdateLiffView` to solve this issue.