### PR TITLE
Fix: Make optional of RequestBody params specified in `oneOf`

### DIFF
--- a/channel-access-token.yml
+++ b/channel-access-token.yml
@@ -299,10 +299,15 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
       description: "Request body to issue a new token with JWT assertion"
       type: object
-      required:
-        - grant_type
-        - client_assertion
-        - client_assertion_type
+      # We are customizing the generator to receive each parameter as an argument directly,
+      # rather than using a struct for the request body.
+      # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
+      # Therefore, we will temporarily define these as optional parameters.
+      # Ref: https://github.com/line/line-bot-sdk-go/issues/464
+      # required:
+      #   - grant_type
+      #   - client_assertion
+      #   - client_assertion_type
       properties:
         grant_type:
           type: string
@@ -320,10 +325,15 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
       description: "Request body to issue a new token with `client_id` and `client_secret`"
       type: object
-      required:
-        - grant_type
-        - client_id
-        - client_secret
+      # We are customizing the generator to receive each parameter as an argument directly,
+      # rather than using a struct for the request body.
+      # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
+      # Therefore, we will temporarily define these as optional parameters.
+      # Ref: https://github.com/line/line-bot-sdk-go/issues/464
+      # required:
+      #   - grant_type
+      #   - client_id
+      #   - client_secret
       properties:
         grant_type:
           type: string

--- a/channel-access-token.yml
+++ b/channel-access-token.yml
@@ -299,15 +299,15 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
       description: "Request body to issue a new token with JWT assertion"
       type: object
-      # We are customizing the generator to receive each parameter as an argument directly,
-      # rather than using a struct for the request body.
-      # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
-      # Therefore, we will temporarily define these as optional parameters.
-      # Ref: https://github.com/line/line-bot-sdk-go/issues/464
-      # required:
-      #   - grant_type
-      #   - client_assertion
-      #   - client_assertion_type
+      required:
+        - grant_type
+        # We are customizing the generator to receive each parameter as an argument directly,
+        # rather than using a struct for the request body.
+        # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
+        # Therefore, we will temporarily define these as optional parameters.
+        # Ref: https://github.com/line/line-bot-sdk-go/issues/464
+        # - client_assertion
+        # - client_assertion_type
       properties:
         grant_type:
           type: string
@@ -325,15 +325,15 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
       description: "Request body to issue a new token with `client_id` and `client_secret`"
       type: object
-      # We are customizing the generator to receive each parameter as an argument directly,
-      # rather than using a struct for the request body.
-      # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
-      # Therefore, we will temporarily define these as optional parameters.
-      # Ref: https://github.com/line/line-bot-sdk-go/issues/464
-      # required:
-      #   - grant_type
-      #   - client_id
-      #   - client_secret
+      required:
+        - grant_type
+        # We are customizing the generator to receive each parameter as an argument directly,
+        # rather than using a struct for the request body.
+        # As a result, specifying the response with `oneOf` causes the required parameters to interfere with each other.
+        # Therefore, we will temporarily define these as optional parameters.
+        # Ref: https://github.com/line/line-bot-sdk-go/issues/464
+        # - client_id
+        # - client_secret
       properties:
         grant_type:
           type: string


### PR DESCRIPTION
This resolves https://github.com/line/line-bot-sdk-go/issues/464.

## Details

The `POST https://api.line.me/oauth2/v3/token` endpoint accepts two types of request bodies:

- [Channel ID request body](https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token-request-body-channel-id)
- [JWT request body](https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token-request-body-jwt)

Each requires different parameters, so in the OpenAPI definition, they are treated as separate RequestBody structures. Ref: [OpenAPI definition link](https://github.com/line/line-openapi/blob/4d9979bb3afa2798fa7dcc489f0fde023a8b25dd/channel-access-token.yml#L32-L34).

However, we have customized the OpenAPI code generation to pass arguments directly to the API function without using RequestBody structures. As a result, even though the required parameters differ for each of the two types of calls, the generated code requires **all parameters to be provided**. Ref: [Generated codes](https://github.com/line/line-bot-sdk-go/blob/2bab995b8094305e09807384e3829874a79259a2/linebot/channel_access_token/api_channel_access_token.go#L420-L432).


This PR seeks to reduce the inconvenience by temporarily making the relevant parameters **optional**.

## Note

Depends on https://github.com/line/line-bot-sdk-go/pull/498

