### PR TITLE
Enable reformat ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,5 @@ jobs:
       with:
         cache: 'npm'
     - run: npx zx ./tools/reformat.mjs
-    - run: git diff --exit-code (Run ./tools/reformat.mjs to format the code)
+    - name: Check there is no diff (Run ./tools/reformat.mjs if there is a diff)
+      run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
@@ -41,3 +41,14 @@ jobs:
         java-version: 17
         architecture: x64
     - run: npx zx ./tools/generate-test.mjs
+
+  format-diff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        cache: 'npm'
+    - run: npx zx ./tools/reformat.mjs
+    - run: git diff --exit-code (Run ./tools/reformat.mjs to format the code)

--- a/channel-access-token.yml
+++ b/channel-access-token.yml
@@ -30,8 +30,8 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               oneOf:
-                - $ref: '#/components/schemas/IssueStatelessChannelTokenByJWTAssertionRequest'
-                - $ref: '#/components/schemas/IssueStatelessChannelTokenByClientSecretRequest'
+                - $ref: "#/components/schemas/IssueStatelessChannelTokenByJWTAssertionRequest"
+                - $ref: "#/components/schemas/IssueStatelessChannelTokenByClientSecretRequest"
       responses:
         "200":
           description: "OK"

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -442,7 +442,7 @@ paths:
             "$ref": "#/components/schemas/AudienceGroupCreateRoute"
           description: |+
             How the audience was created. If omitted, all audiences are included.
-            
+
             `OA_MANAGER`: Return only audiences created with LINE Official Account Manager (opens new window).
             `MESSAGING_API`: Return only audiences created with Messaging API.
       responses:

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3583,7 +3583,7 @@ components:
               type: object
               additionalProperties:
                 $ref: "#/components/schemas/SubstitutionObject"
-              description: "A mapping that specifies substitutions for parts enclosed in {} within the 'text' field."
+              description: "A mapping that specifies substitutions for parts enclosed in {} within the `text` field."
             quoteToken:
               type: string
               description: "Quote token of the message you want to quote."

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3319,7 +3319,7 @@ components:
           unlink: "#/components/schemas/RichMenuBatchUnlinkOperation"
           unlinkAll: "#/components/schemas/RichMenuBatchUnlinkAllOperation"
     RichMenuBatchLinkOperation:
-      description: Replace the rich menu with the rich menu specified in the `to` property for all users linked to the rich menu specified in the `from` property.
+      description: "Replace the rich menu with the rich menu specified in the `to` property for all users linked to the rich menu specified in the `from` property."
       type: object
       required:
         - from
@@ -3333,7 +3333,7 @@ components:
             to:
               type: string
     RichMenuBatchUnlinkOperation:
-      description: Unlink the rich menu for all users linked to the rich menu specified in the `from` property.
+      description: "Unlink the rich menu for all users linked to the rich menu specified in the `from` property."
       type: object
       required:
         - from
@@ -3344,7 +3344,7 @@ components:
             from:
               type: string
     RichMenuBatchUnlinkAllOperation:
-      description: Unlink the rich menu from all users linked to the rich menu.
+      description: "Unlink the rich menu from all users linked to the rich menu."
       type: object
       allOf:
         - "$ref": "#/components/schemas/RichMenuBatchOperation"

--- a/module.yml
+++ b/module.yml
@@ -170,7 +170,7 @@ components:
             The time it takes for initiative (Chat Control) to return to the Primary Channel (the time that the module channel stays on the Active Channel).
             The value is specified in seconds. The maximum value is one year (3600 * 24 * 365).
             The default value is 3600 (1 hour).
-  
+
             * Ignored if the value of expired is false.
           example: 3600
     GetModulesResponse:

--- a/tools/reformat.mjs
+++ b/tools/reformat.mjs
@@ -5,13 +5,29 @@ const fs = require('fs');
 for (let ymlFile of globby.globbySync("*.yml")) {
     console.log(`Processing ${ymlFile}`);
 
-    const src = fs.readFileSync(ymlFile, 'utf-8');
+    await convertSingleQuotesToDoubleQuotes(ymlFile);
+    await trimTrailingWhitespace(ymlFile);
+}
 
-    // convert single quotes to double quotes.
-    let dst = src.replace(/ '([^']+)'/g, ` "$1"`);
+async function convertSingleQuotesToDoubleQuotes(ymlFile) {
+    const content = fs.readFileSync(ymlFile, 'utf-8');
+
+    let dst = content.replace(/ '([^']+)'/g, ` "$1"`);
     dst = dst.replace(/ (\/[^:\n]+):/g, ` "$1":`);
     dst = dst.replace(/(description|summary): ([^|"'][^\n]+)/g,
         (m, key, val) => `${key}: "${val.replace(/"/g, '`')}"`);
 
-    fs.writeFileSync(ymlFile, dst);
+    await fs.writeFileSync(ymlFile, dst);
+}
+
+
+async function trimTrailingWhitespace(ymlFile) {
+    const content = await fs.readFileSync(ymlFile, "utf8");
+
+    const trimmedContent = content
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .join("\n");
+
+    await fs.writeFileSync(ymlFile, trimmedContent, "utf8");
 }

--- a/webhook.yml
+++ b/webhook.yml
@@ -216,7 +216,7 @@ components:
           description: "Type"
         id:
           type: string
-          description: Message ID
+          description: "Message ID"
       discriminator:
         propertyName: type
         mapping:


### PR DESCRIPTION
We already have `reformat.mjs`, but it wasn't enabled in our CI pipeline. This pull request activates it.

If there are any formatting differences, the CI will fail, providing very fast feedback.