### PR TITLE
Add common scripts to get original PR's information in other bot-sdk repositories

### DIFF
--- a/tools/determine-change-type.mjs
+++ b/tools/determine-change-type.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env zx
+
+
+// Call this script from the parent repository
+// This script determines the type of change to the parent repository
+// by checking the latest commit message and the status of the submodule.
+// The possible change types are:
+// - submodule-update: The submodule has been updated.
+// - other: The parent repository has been updated, but the submodule has not been updated.
+// The change type is printed to the console.
+
+const submoduleDir = "line-openapi";
+
+async function determineChangeType() {
+    // Get the latest commit message
+    const { stdout: lastCommit } = await $`git log -1 --pretty=%s`;
+
+    // Get the status of the submodule
+    const { stdout: submoduleStatus } = await $`git submodule status ${submoduleDir}`;
+    const hasUpdate = submoduleStatus.trim().startsWith('+');
+
+    // Determine the type of change
+    if (lastCommit.includes(submoduleDir)) {
+        console.log("submodule-update");
+    } else if (hasUpdate) {
+        console.log("submodule-update");
+    } else {
+        console.log("other");
+    }
+}
+
+await determineChangeType();

--- a/tools/get-pr-info.mjs
+++ b/tools/get-pr-info.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env zx
+
+import fs from "fs/promises";
+
+
+// Call this script from the parent repository
+// This script generates a JSON file containing information about the latest PR
+// that updated the submodule.
+// The JSON file contains the following information:
+// - url: The URL of the PR.
+// - title: The title of the PR.
+// - body: The body of the PR.
+// The JSON file is saved as pr_info.json in the parent repository.
+
+const submoduleDir = "line-openapi";
+const repo = "line/line-openapi";
+
+async function generatePrInfo() {
+    // Change to the submodule directory
+    cd(submoduleDir);
+
+    // Get the latest commit message in the submodule
+    const { stdout: lastCommit } = await $`git log -1 --pretty=%s`;
+    console.log("Last commit in submodule:", lastCommit.trim());
+
+    // Extract the PR number from the commit message
+    const prNumberMatch = lastCommit.match(/#(\d+)/);
+    if (!prNumberMatch) {
+        console.error("No PR number found in submodule's latest commit. Exiting.");
+        process.exit(1);
+    }
+    const prNumber = prNumberMatch[1];
+    console.log("Detected PR number:", prNumber);
+
+    const prUrl = `https://github.com/${repo}/pull/${prNumber}`;
+    console.log("Constructed PR URL:", prUrl);
+
+    // Get the PR title and body
+    const prInfo = JSON.parse(await $`gh pr view ${prNumber} --repo ${repo} --json title,body`);
+    const prTitle = prInfo.title;
+    const prBody = prInfo.body;
+
+    // Save the PR information to a JSON file
+    const output = {
+        url: prUrl,
+        title: prTitle,
+        body: prBody,
+    };
+    await fs.writeFile("../pr_info.json", JSON.stringify(output, null, 2));
+    console.log("PR information saved to pr_info.json");
+
+    // Return to the parent directory
+    cd("..");
+}
+
+await generatePrInfo();


### PR DESCRIPTION
Currently, the bot-sdk repositories automatically create PRs based on updates to line-openapi.

The titles and descriptions of these automatically generated PRs are sometimes filled in by maintainers, but not always. I realized that when creating a PR in the SDK repositories, we can obtain information such as the title and description by retrieving the PR information from line-openapi.

I have implemented and tested a proof of concept for this. Since it seems practical, this change adds scripts to line-openapi. While we could write the same script in each SDK repository, placing it in line-openapi makes maintenance easier. Since line-openapi is registered as a submodule in the bot-sdk repositories, we can call the same script.

In each SDK repository, we need to write a GitHub workflow like the following:
```diff
name: Generate OpenAPI based code

on:
  workflow_dispatch:
  push:
    branches:
      - master

jobs:
  tests:
    name: Generate OpenAPI based code
    runs-on: ubuntu-latest

    steps:
      # Setup
      - uses: actions/checkout@v4
        with:
          submodules: recursive
      - name: Update submodules
        run: git submodule update --remote --recursive
+     - uses: actions/setup-node@v4
      - uses: actions/setup-java@v4
        with:
          distribution: 'temurin'
          java-version: 17
          architecture: x64

      - name: Install Dependency
        run: npm ci

      # Generate codes
      - run: |
          python3 generate-code.py
      - run: |
          diff=$(git --no-pager diff --name-only)
          echo "DIFF_IS_EMPTY='false'" >> $GITHUB_ENV
          echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
      - if: ${{ env.DIFF_IS_EMPTY != 'true' }}
        run: |
+         # Determine Change Type via Submodule Script
+         CHANGE_TYPE=$(npx zx ./line-openapi/tools/determine-change-type.mjs)
+         echo "Determined change type: $CHANGE_TYPE"

+         # Determine PR title and body
+         if [ "$CHANGE_TYPE" == "submodule-update" ]; then
+           # Fetch PR info from submodule
+           npx zx ./line-openapi/tools/get-pr-info.mjs
+           PR_INFO=$(cat pr_info.json)
+           TITLE=$(echo "$PR_INFO" | jq -r '.title')
+           BODY=$(echo "$PR_INFO" | jq -r '.url')$'\n\n'$(echo "$PR_INFO" | jq -r '.body')
+         else
+           # Default PR title and body
+           TITLE="Codes are generated by openapi generator"
+           BODY="⚠Reviewer: Please edit this description to include relevant information about the changes.⚠"
          fi

          BRANCH_NAME="update-diff-${{ env.CURRENT_DATETIME }}"

          git config user.name github-actions
          git config user.email github-actions@github.com
          git checkout -b $BRANCH_NAME

          git add line-openapi
          git add lib/**
          git commit -m "Codes are generated by openapi"

+         git push origin $BRANCH_NAME
+         gh pr create -B ${{ github.ref_name }} -H $BRANCH_NAME -t "$TITLE" -b "$BODY" --label "line-openapi-update"
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```


As a result, we may automate PR title and description like this in each bot-sdk repository:
![image](https://github.com/user-attachments/assets/3be1c19e-2e3e-4c78-83d4-d8dfc2b3aa5e)
