### PR TITLE
Add new errorCode of NarrowcastProgressResponse

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -2728,6 +2728,7 @@ components:
             `1`: An internal error occurred.
             `2`: An error occurred because there weren't enough recipients.
             `3`: A conflict error of requests occurs because a request that has already been accepted is retried.
+            `4`: An audience of less than 50 recipients is included as a condition of sending.
         acceptedTime:
           type: string
           format: date-time


### PR DESCRIPTION
A new errorCode has been added to NarrowcastProgressResponse. 

Previously, it was not possible to determine whether an error occurred due to a lack of enough recipients or because an  audience of less than 50 recipients is included as a condition of sending. This will be fixed with the update to the Messaging API, so the description of errorCode on OpenAPI will also be revised.