### PR TITLE
Sync testing php-sdk

### DIFF
--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -131,7 +131,7 @@ jobs:
           php-version: '8.2'
 
       - name: Install openapi-generator-cli
-        run: echo "OPENAPI_GENERATOR_VERSION=7.10.0" >> $GITHUB_ENV
+        run: echo "OPENAPI_GENERATOR_VERSION=7.11.0" >> $GITHUB_ENV
       - uses: actions/cache@v3
         id: openapi-generator-cache
         env:


### PR DESCRIPTION
follow-up for https://github.com/line/line-bot-sdk-php/pull/667

All generated code is no diff (like https://github.com/line/line-openapi/actions/runs/13825922163/job/38680723524?pr=88#step:8:14). These are expected.