### PR TITLE
Pin commit hash of github actions to avoid supply chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         cache: 'npm'
     - run: npm install -g @stoplight/spectral-cli
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         cache: 'npm'
     - run: npm install -g @openapitools/openapi-generator-cli
     - run: openapi-generator-cli version-manager set 7.0.1
     - run: sed -i -e 's/openapi-generator/openapi-generator-cli/g' ./tools/generate-test.mjs
     - name: actions/setup-java@v3 (JDK 17)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         distribution: 'temurin'
         java-version: 17
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         cache: 'npm'
     - run: npx zx ./tools/reformat.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,12 @@ jobs:
     - run: npx zx ./tools/reformat.mjs
     - name: Check there is no diff (Run ./tools/reformat.mjs if there is a diff)
       run: git diff --exit-code
+
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run pinact
+        uses: suzuki-shunsuke/pinact-action@a6896d13d22e2bf108a78b0c52d3f867c1f41b34 # v0.2.1
+        with:
+          skip_push: "true"

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 0

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout SDK repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'line/line-bot-sdk-java'
           submodules: recursive
@@ -28,7 +28,7 @@ jobs:
 
       # https://github.com/line/line-bot-sdk-java/blob/master/.github/workflows/gradle.yml
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout SDK repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'line/line-bot-sdk-python'
           submodules: recursive
@@ -72,7 +72,7 @@ jobs:
 
       # https://github.com/line/line-bot-sdk-python/blob/master/.github/workflows/auto-testing.yml
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           distribution: 'temurin'
           python-version: '3.11'
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout SDK repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'line/line-bot-sdk-php'
           submodules: recursive
@@ -125,14 +125,14 @@ jobs:
 
       # https://github.com/line/line-bot-sdk-php/blob/master/.github/workflows/php-checks.yml
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # 2.32.0
         with:
           distribution: 'temurin'
           php-version: '8.2'
 
       - name: Install openapi-generator-cli
         run: echo "OPENAPI_GENERATOR_VERSION=7.11.0" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: openapi-generator-cache
         env:
           cache-name: openapi-generator-cache
@@ -157,7 +157,7 @@ jobs:
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
@@ -165,7 +165,7 @@ jobs:
             ${{ runner.os }}-php-${{ matrix.php }}-
 
       - name: Install dependencies with Composer
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # 3.1.0
 
       - name: Show diff
         run: |
@@ -186,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout SDK repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'line/line-bot-sdk-nodejs'
           submodules: recursive
@@ -203,14 +203,14 @@ jobs:
 
       # https://github.com/line/line-bot-sdk-nodejs/blob/master/.github/workflows/test.yml
       - name: actions/setup-java@v3
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
           java-version: 17
           architecture: x64
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '20'
 
@@ -239,7 +239,7 @@ jobs:
 
     steps:
       - name: Checkout SDK repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'line/line-bot-sdk-go'
           submodules: recursive
@@ -256,19 +256,19 @@ jobs:
 
       # https://github.com/line/line-bot-sdk-go/blob/master/.github/workflows/go.yml
       - name: actions/setup-java@v3
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
           java-version: 17
           architecture: x64
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.x'
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.21
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "timezone": "Asia/Tokyo",
+  "automerge": true,
+  "platformAutomerge": true,
+}


### PR DESCRIPTION
## Changes
To avoid supply chain attacks, specify actions in GitHub Actions workflows using commit hashes instead of version numbers. Pinact-action will fail the CI job if this is not done. Renovate already supports updates in the commit hash state, so there is no issue.

(At this point, since this repository provides YAML, it might be considered unnecessary, but having it prepared doesn't hurt.)


## References
- https://github.com/suzuki-shunsuke/pinact-action
  - does pinact-action verify the checksum of the version of aqua it is using? Yes!: 
- https://github.com/suzuki-shunsuke/pinact

## Other repositories
- line/line-bot-sdk-python
- line/line-bot-sdk-php
- line/line-bot-sdk-nodejs
- line/line-bot-sdk-java
- line/line-bot-sdk-go
- line/line-bot-sdk-ruby
- line/line-openapi