### PR TITLE
Refine job-level permissions to enhance supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js
@@ -24,7 +25,8 @@ jobs:
 
   generate-test:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js
@@ -44,7 +46,8 @@ jobs:
 
   format-diff:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   test-java:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -52,7 +55,10 @@ jobs:
 
   test-python:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -105,7 +111,10 @@ jobs:
 
   test-php:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -183,7 +192,10 @@ jobs:
 
   test-nodejs:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -236,7 +248,10 @@ jobs:
 
   test-go:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Changes

This PR specifies minimal permissions on each job to reduce unnecessary access to repository contents and avoid potential security risks. By granting only the required scopes (e.g. read-only for repository contents and write access only for issues to post PR comments), we can protect the supply chain from unintended privilege escalations.