### PR TITLE
Warn PR from forked repository

### DIFF
--- a/.github/workflows/warn-pr-from-forked-repository.yml
+++ b/.github/workflows/warn-pr-from-forked-repository.yml
@@ -1,0 +1,36 @@
+name: Warn PR from forked repository
+
+on:
+  # Intentional: forked repository doesn't have write permission to the base repository.
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  comment-on-forked-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Add a comment if PR is from a fork
+        if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
+        run: |
+          PR_AUTHOR=${{ github.event.pull_request.user.login }}
+          COMMENT=":warning: Attention @$PR_AUTHOR!
+            Thank you for your interest in contributing to this repository!
+
+            This repository primarily exists to convert publicly available LINE APIs into OpenAPI YAML, making it easier for developers to access the features.
+            Our employees mainly update the schema based on the latest features and changes in our APIs.
+            
+            Therefore, it is not intended for open contributions by editing files in this repository, from outside contributors.
+
+            Please start by creating an issue and discussing it there. You may close this pull request and create an issue instead.
+
+            ==
+            If you are an employee participating in this organization, please push branches directly to this repository to create PR, instead of using a forked repository.
+          "
+          
+          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ If you have an interesting use case for these files or have a request, please cr
 |                          |                 |                                                                                           |                          |
 | webhook.yml              | 3.0.3           |                                                                                           | Webhook Event Objects    |
 
+## How to Contribute
+
+Thank you for your interest in contributing to the **line/line-openapi** repository!
+This project just publishes our public features as an OpenAPI schema to help developers easily access and integrate with them.
+Our employees mainly update the schema based on the latest features and changes in our APIs.
+
+Please note the following guidelines:
+
+1. **Pull Requests**  
+   We currently only accept Pull Requests from our employees.
+
+2. **Issues First**  
+   If you would like to propose a change, or discuss a problem, please open an issue first.
 
 ## Known issues
 


### PR DESCRIPTION
This repository is public, but contributions are primarily expected from our employees. Additionally, some automations are disabled for forked repositories (technically possible, but not implemented).

Even the main contributors sometimes forget not to use forked repos. Using a forked repo causes CI to fail, but it takes time to remember this. Therefore, this change starts to remind contributors to push branches to this repository instead of using forked repos.

(example)
![image](https://github.com/user-attachments/assets/25adfb1d-9787-42df-bd7f-c31d191e75cf)


This change also adds this expectation to the README. Generally, discussions should be held in issues at first unless it's a really trivial typo. Even if we have valid reasons, it's disheartening to reject contributions after someone has put in the effort.