### PR TITLE
Delete comment for php's webhook parser

### DIFF
--- a/.github/actions/post-comment-action/main.js
+++ b/.github/actions/post-comment-action/main.js
@@ -66,7 +66,7 @@ async function run() {
             `[Check the diff here](${url})`;
 
         // for warning
-        if (language === 'ruby' || language === 'php') {
+        if (language === 'ruby') {
             const { data: files } = await octokit.rest.pulls.listFiles({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
https://github.com/line/line-bot-sdk-php/pull/677 completed https://github.com/line/line-bot-sdk-php/issues/673 so we don't have to care this. Let's delete comment for line-bot-sdk-php in CI in this repository.