### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Basic CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   setup:

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -1,9 +1,10 @@
 name: SDK Test Automation
 
 on:
+  push:
   pull_request:
-    branches:
-      - main
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   test-java:


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.

original: https://github.com/line/line-bot-sdk-java/pull/1592