### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Basic CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   setup:

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -2,11 +2,7 @@ name: SDK Test Automation
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -1,9 +1,10 @@
 name: SDK Test Automation
 
 on:
+  push:
   pull_request:
-    branches:
-      - main
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   test-java:

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -2,7 +2,11 @@ name: SDK Test Automation
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -40,6 +40,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
+        if : ${{ github.event_name == 'pull_request' }}
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: java
@@ -85,6 +86,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
+        if : ${{ github.event_name == 'pull_request' }}
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: python
@@ -159,6 +161,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
+        if : ${{ github.event_name == 'pull_request' }}
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: php
@@ -209,6 +212,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
+        if : ${{ github.event_name == 'pull_request' }}
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: nodejs
@@ -264,6 +268,7 @@ jobs:
           git diff --color=always --staged
 
       - name: Post PR comment
+        if : ${{ github.event_name == 'pull_request' }}
         uses: ./line-openapi/.github/actions/post-comment-action
         with:
           language: go

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -1,13 +1,14 @@
 name: SDK Test Automation
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
-  ## This workflow is only for testing remote bot sdk repositories. We don't have to run this workflow for the main repository.
-  # merge_group:
-  # push:
-  # workflow_dispatch
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   test-java:
@@ -22,15 +23,29 @@ jobs:
           repository: 'line/line-bot-sdk-java'
           submodules: recursive
 
-      - name: Update line-openapi submodule
+      - name: Update line-openapi submodule (only when pull request)
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           cd line-openapi
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
+          
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "This is a pull request event"
+            git remote add pr-source $PR_REPO_URL
+            git fetch pr-source $PR_REF
+            git checkout FETCH_HEAD
+          fi
         env:
           PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           PR_REF: ${{ github.event.pull_request.head.ref }}
+
+      - name: Update line-openapi submodule (not when pull request)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          cd line-openapi
+
+          echo "This is ${ github.event_name } event"
+          git checkout main
+          git pull origin main
 
       # https://github.com/line/line-bot-sdk-java/blob/master/.github/workflows/gradle.yml
       - name: Setup Java

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -27,13 +27,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           cd line-openapi
-          
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "This is a pull request event"
-            git remote add pr-source $PR_REPO_URL
-            git fetch pr-source $PR_REF
-            git checkout FETCH_HEAD
-          fi
+
+          echo "This is a pull request event"
+          git remote add pr-source $PR_REPO_URL
+          git fetch pr-source $PR_REF
+          git checkout FETCH_HEAD
         env:
           PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           PR_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -104,14 +104,9 @@ jobs:
           submodules: recursive
 
       - name: Update line-openapi submodule
-        run: |
-          cd line-openapi
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
-        env:
-          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_REF: ${{ github.event.pull_request.head.ref }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: './line-openapi'
 
       # https://github.com/line/line-bot-sdk-php/blob/master/.github/workflows/php-checks.yml
       - name: Setup PHP
@@ -183,14 +178,9 @@ jobs:
           submodules: recursive
 
       - name: Update line-openapi submodule
-        run: |
-          cd line-openapi
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
-        env:
-          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_REF: ${{ github.event.pull_request.head.ref }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: './line-openapi'
 
       # https://github.com/line/line-bot-sdk-nodejs/blob/master/.github/workflows/test.yml
       - name: Setup Java
@@ -238,14 +228,9 @@ jobs:
           submodules: recursive
 
       - name: Update line-openapi submodule
-        run: |
-          cd line-openapi
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
-        env:
-          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_REF: ${{ github.event.pull_request.head.ref }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: './line-openapi'
 
       # https://github.com/line/line-bot-sdk-go/blob/master/.github/workflows/go.yml
       - name: Setup Java

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -1,14 +1,13 @@
 name: SDK Test Automation
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-  merge_group:
-  workflow_dispatch:
+  ## This workflow is only for testing remote bot sdk repositories. We don't have to run this workflow for the main repository.
+  # merge_group:
+  # push:
+  # workflow_dispatch
 
 jobs:
   test-java:

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           path: './line-openapi'
 
+      # https://github.com/line/line-bot-sdk-python/blob/master/.github/workflows/auto-testing.yml
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -23,27 +23,10 @@ jobs:
           repository: 'line/line-bot-sdk-java'
           submodules: recursive
 
-      - name: Update line-openapi submodule (only when pull request)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          cd line-openapi
-
-          echo "This is a pull request event"
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
-        env:
-          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_REF: ${{ github.event.pull_request.head.ref }}
-
-      - name: Update line-openapi submodule (not when pull request)
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          cd line-openapi
-
-          echo "This is ${ github.event_name } event"
-          git checkout main
-          git pull origin main
+      - name: Update line-openapi submodule
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: './line-openapi'
 
       # https://github.com/line/line-bot-sdk-java/blob/master/.github/workflows/gradle.yml
       - name: Setup Java
@@ -82,20 +65,9 @@ jobs:
           submodules: recursive
 
       - name: Update line-openapi submodule
-        run: |
-          cd line-openapi
-          git remote add pr-source $PR_REPO_URL
-          git fetch pr-source $PR_REF
-          git checkout FETCH_HEAD
-        env:
-          PR_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_REF: ${{ github.event.pull_request.head.ref }}
-
-      # https://github.com/line/line-bot-sdk-python/blob/master/.github/workflows/auto-testing.yml
-      - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          python-version: '3.11'
+          path: './line-openapi'
 
       - name: Install dependencies
         run: |

--- a/webhook.yml
+++ b/webhook.yml
@@ -503,9 +503,6 @@ components:
               type: string
               description: |+
                 Message ID of a quoted message. Only included when the received message quotes a past message.
-            hello:
-              type: string
-              default: aaaa this is test.
 
     # https://developers.line.biz/en/reference/messaging-api/#unsend-event
     UnsendEvent:

--- a/webhook.yml
+++ b/webhook.yml
@@ -503,6 +503,9 @@ components:
               type: string
               description: |+
                 Message ID of a quoted message. Only included when the received message quotes a past message.
+            hello:
+              type: string
+              default: aaaa this is test.
 
     # https://developers.line.biz/en/reference/messaging-api/#unsend-event
     UnsendEvent:


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.

original: https://github.com/line/line-bot-sdk-java/pull/1592


Additionally, by using actions/checkout, this change modifies how to inject the latest openapi schema so that the bot SDK tests always run with the latest line-openapi, even outside of PRs. This will be a safer approach.