### PR TITLE
Add type as required property in source object of webhook

### DIFF
--- a/webhook.yml
+++ b/webhook.yml
@@ -136,6 +136,8 @@ components:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#source-user
       description: "the source of the event."
+      required:
+        - type
       type: object
       properties:
         type:


### PR DESCRIPTION
In the Messaging API webhook, we use `discriminator` to differentiate classes based on the value of `type`. During the development of bot SDK for Ruby v2, it seems that only `Source` does not have `type` marked as required. This is simply a mistake. The type should always be included to distinguish the kind of JSON, and there should not be any instances where it is absent.