### PR TITLE
Add includesOwnedAudienceGroups Parameter to Audience API

### DIFF
--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -256,26 +256,6 @@ paths:
         "200":
           description: "OK"
 
-  "/v2/bot/audienceGroup/{audienceGroupId}/activate":
-    put:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#activate-audience-group
-      tags:
-        - manage-audience
-      operationId: activateAudienceGroup
-      description: "Activate audience"
-      parameters:
-        - name: audienceGroupId
-          in: path
-          required: true
-          description: "The audience ID."
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "202":
-          description: "Accepted"
-
   "/v2/bot/audienceGroup/{audienceGroupId}":
     parameters:
       - name: audienceGroupId
@@ -494,41 +474,6 @@ paths:
                     readWriteAudienceGroupTotalCount: 0
                     size: 40
                     page: 1
-
-  "/v2/bot/audienceGroup/authorityLevel":
-    get:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-authority-level
-      tags:
-        - manage-audience
-      operationId: getAudienceGroupAuthorityLevel
-      description: "Get the authority level of the audience"
-      responses:
-        "200":
-          description: "OK"
-          content:
-            "application/json":
-              schema:
-                "$ref": "#/components/schemas/GetAudienceGroupAuthorityLevelResponse"
-              example:
-                authorityLevel: PUBLIC
-    put:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#change-authority-level
-      tags:
-        - manage-audience
-      operationId: updateAudienceGroupAuthorityLevel
-      description: "Change the authority level of the audience"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/UpdateAudienceGroupAuthorityLevelRequest"
-        required: true
-      responses:
-        "200":
-          description: "OK"
-          # empty json response
 
   "/v2/bot/audienceGroup/shared/{audienceGroupId}":
     parameters:
@@ -1260,28 +1205,6 @@ components:
           type: integer
           format: int64
           description: "The maximum number of audiences on the current page."
-    GetAudienceGroupAuthorityLevelResponse:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#get-authority-level
-      type: object
-      description: "Get the authority level of the audience"
-      properties:
-        authorityLevel:
-          "$ref": "#/components/schemas/AudienceGroupAuthorityLevel"
-    AudienceGroupAuthorityLevel:
-      description: "authority level"
-      type: string
-      enum:
-        - PUBLIC
-        - PRIVATE
-    UpdateAudienceGroupAuthorityLevelRequest:
-      externalDocs:
-        url: https://developers.line.biz/en/reference/messaging-api/#change-authority-level
-      type: object
-      description: "Change the authority level of the audience"
-      properties:
-        authorityLevel:
-          "$ref": "#/components/schemas/AudienceGroupAuthorityLevel"
 
     ErrorResponse:
       externalDocs:

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -633,8 +633,8 @@ paths:
             type: boolean
             default: false
           description: |+
-            true: Include audienceGroups owned by the user
-            false: Respond only audienceGroups shared by BM
+            true: Include audienceGroups owned by LINE Official Account Manager
+            false: Respond only audienceGroups shared by Business Manager
       responses:
         "200":
           description: "OK"

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -681,6 +681,15 @@ paths:
 
             `OA_MANAGER`: Return only audiences created with LINE Official Account Manager (opens new window).
             `MESSAGING_API`: Return only audiences created with Messaging API.
+        - name: includesOwnedAudienceGroups
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |+
+            true: Include audienceGroups owned by the user
+            false: Respond only audienceGroups shared by BM
       responses:
         "200":
           description: "OK"


### PR DESCRIPTION
# Enhancement to Shared Audiences API

This PR introduces a new query parameter `includesOwnedAudienceGroups` to the `/v2/bot/audienceGroup/shared/list` endpoint in the Business Manager API. This enhancement allows users to specify whether to include audience groups owned by the user in the response.

## Changes Made
- Added the `includesOwnedAudienceGroups` parameter to the API endpoint.
  - **Type**: Boolean
  - **Default**: false
  - **Description**: 
    - `true`: Include audience groups owned by the LINE Official Account Manager.
    - `false`: Respond only with audience groups shared by Business Manager.
- Removed the `/v2/bot/audienceGroup/{audienceGroupId}/activate` and `/v2/bot/audienceGroup/authorityLevel` endpoints.

## Purpose
This update provides more flexibility in retrieving audience groups by allowing users to filter based on ownership. It is especially useful for users who manage both shared and owned audience groups. The removal of certain endpoints is part of a cleanup effort to streamline the API.

Please review the changes and let me know if there are any questions or further modifications needed.

## Documents and Reference
- [Get List of Shared Audiences](https://developers.line.biz/en/reference/messaging-api/#get-shared-audience-list)
- [Removed Endpoints](https://developers.line.biz/en/news/2025/03/26/cross-targeting-closing/)

For more information, please refer to the links provided above.
