### PR TITLE
Warn if underscore is contained in JSON for request body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,22 @@ jobs:
     - name: Check there is no diff (Run ./tools/reformat.mjs if there is a diff)
       run: git diff --exit-code
 
+  property-should-be-camelcase:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        # ensures origin/main is available for git show
+        fetch-depth: 0
+    - name: Use Node.js
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      with:
+        cache: 'npm'
+    - run: npm install
+    - run: node tools/validate-property-camelcase.mjs
+
   pinact:
     runs-on: ubuntu-latest
     steps:

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -1055,7 +1055,7 @@ components:
           "$ref": "#/components/schemas/AudienceGroupJobStatus"
         failedType:
           "$ref": "#/components/schemas/AudienceGroupJobFailedType"
-        audienceCount:
+        audience_count:
           type: integer
           format: int64
           description: "The number of accounts (recipients) that were added or removed."

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -1055,7 +1055,7 @@ components:
           "$ref": "#/components/schemas/AudienceGroupJobStatus"
         failedType:
           "$ref": "#/components/schemas/AudienceGroupJobFailedType"
-        audience_count:
+        audienceCount:
           type: integer
           format: int64
           description: "The number of accounts (recipients) that were added or removed."

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "ibm-openapi-validator": "^0.97.5"
+        "ibm-openapi-validator": "^0.97.5",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -668,12 +669,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -1676,6 +1675,28 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ibm-openapi-validator/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ibm-openapi-validator/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1968,12 +1989,12 @@
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2005,6 +2026,28 @@
         "debug": "^3.1.0",
         "js-yaml": "^3.12.0",
         "ono": "^4.0.6"
+      }
+    },
+    "node_modules/json-schema-ref-parser/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2782,7 +2825,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stacktracey": {
       "version": "2.1.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "ibm-openapi-validator": "^0.97.5"
+    "ibm-openapi-validator": "^0.97.5",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/tools/validate-property-camelcase.mjs
+++ b/tools/validate-property-camelcase.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import yaml from 'js-yaml';
+
+/**
+ * Recursively collect all files under the given directory
+ * that have a .yml or .yaml extension.
+ */
+async function collectYamlFiles(dir) {
+    const excludeDirs = new Set(['node_modules', '.github']);
+    let results = [];
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        // Skip excluded directories
+        if (entry.isDirectory() && excludeDirs.has(entry.name)) {
+            continue;
+        }
+
+        if (entry.isDirectory()) {
+            const sub = await collectYamlFiles(fullPath);
+            results = results.concat(sub);
+        } else if (entry.isFile() && /\.(ya?ml)$/i.test(entry.name)) {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}
+
+/**
+ * Parse the given YAML string into a JavaScript object.
+ * Throws an error if parsing fails.
+ */
+function parseYaml(content) {
+    try {
+        return yaml.load(content) || {};
+    } catch (err) {
+        throw new Error(`YAML parse error: ${err.message}`);
+    }
+}
+
+/**
+ * Return all property paths in the object as an array of strings.
+ * Each path is in the form "parent.child.key".
+ * Arrays are traversed, but their indices are not included in the paths.
+ */
+function getAllObjectPaths(obj, prefix = '') {
+    if (obj === null || typeof obj !== 'object') return [];
+    if (Array.isArray(obj)) {
+        return obj.flatMap(item => getAllObjectPaths(item, prefix));
+    }
+    let paths = [];
+    for (const key of Object.keys(obj)) {
+        const full = prefix ? `${prefix}.${key}` : key;
+        paths.push(full);
+        const child = obj[key];
+        if (child !== null && typeof child === 'object') {
+            paths = paths.concat(getAllObjectPaths(child, full));
+        }
+    }
+    return paths;
+}
+
+/**
+ * Compare the old and new objects and return an array of paths
+ * that are present in newObj but not in oldObj.
+ */
+function getNewKeys(oldObj, newObj) {
+    const oldSet = new Set(getAllObjectPaths(oldObj));
+    return getAllObjectPaths(newObj).filter(p => !oldSet.has(p));
+}
+
+/**
+ * Check if the object represents an OpenAPI definition.
+ * Returns true if the root has an "openapi" property.
+ */
+function isOpenApi(obj) {
+    return obj && typeof obj === 'object' &&
+        Object.prototype.hasOwnProperty.call(obj, 'openapi');
+}
+
+async function main() {
+    const cwd = process.cwd();
+    const yamlFiles = await collectYamlFiles(cwd);
+    let hasError = false;
+
+    for (const filePath of yamlFiles) {
+        console.log(`Processing ${filePath}...`);
+        // Read the new (HEAD) file content
+        let newContent;
+        try {
+            newContent = await fs.readFile(filePath, 'utf8');
+        } catch {
+            continue; // Skip if file cannot be read
+        }
+
+        // Get the old file content from origin/main (empty if not present)
+        let oldContent = '';
+        try {
+            oldContent = execSync(`git show origin/main:${filePath}`, { encoding: 'utf8' });
+        } catch {
+            oldContent = '';
+        }
+
+        // Parse YAML contents
+        let newObj, oldObj;
+        try {
+            newObj = parseYaml(newContent);
+            oldObj = parseYaml(oldContent);
+        } catch (err) {
+            console.warn(`Warning: parse error in ${filePath}: ${err.message}`);
+            continue;
+        }
+        console.log(`Parsed ${filePath} successfully.`);
+
+        // Skip files that are not OpenAPI definitions
+        if (!isOpenApi(newObj)) {
+            continue;
+        }
+        console.log(`Checking ${filePath}...`);
+
+        // Get keys newly added in newObj compared to oldObj
+        const newKeys = getNewKeys(oldObj, newObj);
+
+        // Filter paths whose last segment contains an underscore
+        const invalid = newKeys.filter(p => {
+            const last = p.split('.').pop();
+            return last.includes('_');
+        });
+
+        if (invalid.length) {
+            hasError = true;
+            console.error(`\n[ERROR] ${filePath}: the following newly added keys contain underscores:`);
+            invalid.forEach(p => console.error(`  - ${p}`));
+        }
+    }
+
+    if (hasError) {
+        process.exit(1);
+    } else {
+        console.log('OK: No underscores found in newly added OpenAPI keys.');
+    }
+}
+
+main();


### PR DESCRIPTION
line-bot-sdk-ruby v2.0.0 automatically converts underscores of JSON's key in the request body to camel case. Thus, if there are properties with underscores, the request will fail due to this implementation. 
In the first place, many LINE developers' products uses already camel case in so many features, so there's no reason to use underscores as of now. (though we know some properties use underscores... we can't revert it after publishing it)

This change adds a workflow and script that will cause CI to fail if underscores might be included, reminding us of this fact.