### PR TITLE
Specify stable version for actions/setup-go

### DIFF
--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -257,9 +257,9 @@ jobs:
           python-version: '3.x'
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.21
+          go-version: stable
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
This is almost same as https://github.com/line/line-bot-sdk-go/pull/585. we don't have to maintain actual go version in github actions workflow.