### PR TITLE
add the open api execute command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-.PHONY: docker/open-api-doc
-PORT ?= 8080
-docker/open-api-doc:
-	docker run --rm --name line-open-api-doc \
-	-p $(PORT):8080 \
-	-e PORT=8080 \
-	-e API_URL=/openapi/messaging-api.yml \
-	-v ./:/usr/share/nginx/html/openapi \
-	swaggerapi/swagger-ui:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: docker/open-api-doc
+PORT ?= 8080
+docker/open-api-doc:
+	docker run --rm --name line-open-api-doc \
+	-p $(PORT):8080 \
+	-e PORT=8080 \
+	-e API_URL=/openapi/messaging-api.yml \
+	-v ./:/usr/share/nginx/html/openapi \
+	swaggerapi/swagger-ui:latest

--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ Please note the following guidelines:
 ## Usage
 
 You can launch the Swagger UI to browse the OpenAPI specs locally using Docker.
+First, make sure you have `docker-compose.yml` in this directory. Then run:
 
 ```sh
-docker run --rm --name line-open-api-doc -p 8080:8080 -e PORT=8080 -e API_URL=/openapi/messaging-api.yml -v ./:/usr/share/nginx/html/openapi swaggerapi/swagger-ui:latest
+docker-compose up
 ```
 
 By default, the Swagger UI will be available at: [http://localhost:8080](http://localhost:8080)
+
+### Using Docker Command
+
+Alternatively, you can use the following Docker command:

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ Please note the following guidelines:
 
 - OpenAPI Generator can't generate Python client with Java 17+
   - https://github.com/OpenAPITools/openapi-generator/issues/13684
+
+## Usage
+
+You can launch the Swagger UI to browse the OpenAPI specs locally using Docker and the provided Makefile.
+
+```sh
+make docker/open-api-doc
+```
+
+By default, the Swagger UI will be available at: [http://localhost:8080](http://localhost:8080)
+
+If you want to use a different port, edit the `-p` option in the `Makefile`.

--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ Please note the following guidelines:
 
 ## Usage
 
-You can launch the Swagger UI to browse the OpenAPI specs locally using Docker and the provided Makefile.
+You can launch the Swagger UI to browse the OpenAPI specs locally using Docker.
 
 ```sh
-make docker/open-api-doc
+docker run --rm --name line-open-api-doc -p 8080:8080 -e PORT=8080 -e API_URL=/openapi/messaging-api.yml -v ./:/usr/share/nginx/html/openapi swaggerapi/swagger-ui:latest
 ```
 
 By default, the Swagger UI will be available at: [http://localhost:8080](http://localhost:8080)
-
-If you want to use a different port, edit the `-p` option in the `Makefile`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  swagger-ui:
+    image: swaggerapi/swagger-ui:latest
+    container_name: line-open-api-doc
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080
+      - API_URL=/openapi/messaging-api.yml
+    volumes:
+      - ./:/usr/share/nginx/html/openapi


### PR DESCRIPTION
Docker is a helpful tool for developers.
However, this repository doesn't have a manual to stand up Docker.
Therefore, I added the Docker command to the Makefile and README.md.