### PR TITLE
Add new AudienceGroupType POP_AD_IMP to Audience Group API 

### DIFF
--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -794,6 +794,7 @@ components:
         - IMAGE_CLICK
         - RICHMENU_IMP
         - RICHMENU_CLICK
+        - POP_AD_IMP
     AddAudienceToAudienceGroupRequest:
       externalDocs:
         url: https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group


### PR DESCRIPTION
# Add `POP_AD_IMP` to **AudienceGroupType** Enum

We have supported for the new audience‑group type **`POP_AD_IMP`** (POP ad impression audience) to the OpenAPI schema.

## Changes Made

* **Updated `AudienceGroupType` enumeration**

  * **New value**: `POP_AD_IMP`
  * **Description**: Audience groups generated from impressions of *LINE Beacon Network* (POP) ads.
  * **Region**: **Taiwan‑only** at launch

## Purpose

This update enables correct identification and handling of audience groups built from POP ad impressions, a feature that will be released for the Taiwan market.

## Documents and Reference

- [Managing Audience](https://developers.line.biz/en/reference/messaging-api/#manage-audience-group)

For more information, please refer to the links provided above.