### PR TITLE
Add forbidPartialDelivery option to the Narrowcast Limit Object

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -2894,6 +2894,7 @@ components:
             `2`: An error occurred because there weren't enough recipients.
             `3`: A conflict error of requests occurs because a request that has already been accepted is retried.
             `4`: An audience of less than 50 recipients is included as a condition of sending.
+            `5`: Message delivery has been canceled to prevent messages from being delivered only to a subset of the target audience.
         acceptedTime:
           type: string
           format: date-time


### PR DESCRIPTION
## Add forbidPartialDelivery option to the Narrowcast Limit Object

We add a new `forbidPartialDelivery` option to the Narrowcast Limit Object.

When set to true, this option prevents messages from being delivered to only a subset of the target audience.
If partial delivery occurs, the narrowcast request will succeed but fail asynchronously.
You can verify whether the message delivery was canceled by checking the narrowcast message progress.

This property can only be set to true when upToRemainingQuota is also true.

For more details, see the https://developers.line.biz/en/news/2025/10/21/narrowcast-message-update/.

### Example:
```json
{
  "max": 100,
  "upToRemainingQuota": true,
  "forbidPartialDelivery": true
}
```