### PR TITLE
Make body in setRichMenuImage required

### DIFF
--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -1216,6 +1216,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           "*/*":
             schema:

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -1746,7 +1746,7 @@ paths:
       tags:
         - messaging-api
       operationId: getPNPMessageStatistics
-      description: "Get number of sent LINE notification messages　"
+      description: "Get number of sent LINE notification messages"
       parameters:
         - name: date
           in: query


### PR DESCRIPTION
While upgrading the Node.js SDK to TypeScript v6, I noticed that the `binary` parameter for `setRichMenuImage` is incorrectly marked as optional. You can't set a rich menu image without the image data, so it should never be optional. This change corrects this.

Looking at the generated code, this issue affects all SDKs except for Go. While the real-world impact is likely minor, since users would quickly realize the image is necessary and wouldn't keep sending requests without it. Anyway the API definition in the YAML should be accurate. Let's ensure it reflects the correct, required state.

I also checked other APIs, but only the `setRichMenuImage` forgets this, so we don't have to modify others as of now.