### PR TITLE
Remove null from `AudienceGroupFailedType` emum

### DIFF
--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -1107,7 +1107,6 @@ components:
       enum:
         - AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT
         - INTERNAL_ERROR
-        - null
     AudienceGroupPermission:
       description: "Permission"
       type: string


### PR DESCRIPTION
null as `AudienceGroupFailedType` enum was mistakenly added. It's bug.
Actually it was not returned from the API.
This change removes it. 