### PR TITLE
Add missing required and drop unnecessary required

### DIFF
--- a/insight.yml
+++ b/insight.yml
@@ -125,7 +125,7 @@ paths:
       parameters:
         - in: query
           name: date
-          required: false
+          required: true
           description: |+
             Date for which to retrieve the number of followers.
 

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -827,6 +827,8 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#create-click-audience-group
       type: object
       description: "Create audience for click-based retargeting"
+      required:
+        - description
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -82,6 +82,7 @@ paths:
               description: "Request for createAudienceForUploadingUserIds"
               type: object
               required:
+                - description
                 - file
               properties:
                 description:

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -584,7 +584,7 @@ paths:
       parameters:
         - name: page
           in: query
-          required: true
+          required: false
           schema:
             type: integer
             format: int64

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -804,6 +804,8 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group
       type: object
       description: "Add user IDs or Identifiers for Advertisers (IFAs) to an audience for uploading user IDs (by JSON)"
+      required:
+        - audienceGroupId
       properties:
         audienceGroupId:
           type: integer

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -911,6 +911,7 @@ components:
       description: "Create audience for impression-based retargeting"
       required:
         - description
+        - requestId
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -829,6 +829,7 @@ components:
       description: "Create audience for click-based retargeting"
       required:
         - description
+        - requestId
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -143,6 +143,7 @@ paths:
               description: "Request of the addUserIdsToAudience"
               type: object
               required:
+                - audienceGroupId
                 - file
               properties:
                 audienceGroupId:

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -698,6 +698,8 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#create-upload-audience-group
       type: object
       description: "Create audience for uploading user IDs (by JSON)"
+      required:
+        - description
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -909,6 +909,8 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#create-imp-audience-group
       type: object
       description: "Create audience for impression-based retargeting"
+      required:
+        - description
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -953,6 +953,8 @@ components:
         url: https://developers.line.biz/en/reference/messaging-api/#set-description-audience-group
       type: object
       description: "Rename an audience"
+      required:
+        - description
       properties:
         description:
           type: string

--- a/manage-audience.yml
+++ b/manage-audience.yml
@@ -806,6 +806,7 @@ components:
       description: "Add user IDs or Identifiers for Advertisers (IFAs) to an audience for uploading user IDs (by JSON)"
       required:
         - audienceGroupId
+        - audiences
       properties:
         audienceGroupId:
           type: integer

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -5273,6 +5273,7 @@ components:
         - acquisitionCondition
         - endTimestamp
         - maxUseCountPerTicket
+        - reward
         - startTimestamp
         - title
         - visibility

--- a/messaging-api.yml
+++ b/messaging-api.yml
@@ -3261,6 +3261,12 @@ components:
     # RichMenu
     RichMenuRequest:
       type: object
+      required:
+        - size
+        - selected
+        - name
+        - chatBarText
+        - areas
       properties:
         size:
           "$ref": "#/components/schemas/RichMenuSize"


### PR DESCRIPTION
There is an inconsistency between the OpenAPI specification (and generated SDKs) and the actual API behavior.
This change updates the required or optional annotations to match the actual behavior.

The behavior of the Messaging API itself is unchanged at all. This is purely a bug fix for the OpenAPI spec and the generated SDKs.

## Affected methods

| operationId | parameter | fix |
|---|---|---|
| `createAudienceGroup` | `description` | missing required |
| `createAudienceForUploadingUserIds` | `description` | missing required |
| `addAudienceToAudienceGroup` | `audienceGroupId` | missing required |
| - | `audiences` | missing required |
| `addUserIdsToAudience` | `audienceGroupId` | missing required |
| `createClickBasedAudienceGroup` | `description` | missing required |
| - | `requestId` | missing required |
| `createImpBasedAudienceGroup` | `description` | missing required |
| - | `requestId` | missing required |
| `updateAudienceGroupDescription` | `description` | missing required |
| `getNumberOfFollowers` | `date` | incorrectly marked as optional |
| `createRichMenu` / `validateRichMenuObject` | `size`, `selected`, `name`, `chatBarText`, `areas` | missing required |
| `createCoupon` | `reward` | missing required |
| `getSharedAudienceGroups` | `page` | incorrectly marked as required |


## bot sdks we must fix 
we must fix test depending on this.
go, ruby, nodejs, java are affected. line-openapi-126-prepare branch has this fix.
also https://github.com/line/line-openapi/pull/126/commits/5c8b8c446271504c6ca96639fa35da8c6aca636f tested these remote branches, and https://github.com/line/line-openapi/actions/runs/31403474364?pr=126 showed all jobs were passed.